### PR TITLE
Add a common library for state-based causal CRDTs & an optimised orset type

### DIFF
--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -253,7 +253,7 @@ get_maxs_for_all(DotCloud) ->
                                  {value, {_DotActor, C}, ModList} ->
                                      {max(DotCounter0, C), ModList}
                              end,
-                         [{DotActor0,Counter}|NewList]
+                         [{DotActor0, Counter}|NewList]
                  end, [], DotCloud).
 
 %% @private

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -43,7 +43,7 @@
 -export([new_data_store/1,
          is_bottom_data_store/1]).
 %% {{dot_map, data_store_type()}, dot_map()} related.
--export([get_data_store/2,
+-export([get_sub_data_store/2,
          insert_object/3,
          remove_object/2,
          get_all_objects/1,
@@ -164,8 +164,8 @@ causal_join({{{dot_map, ValueDataStoreType}, DataStoreA}=Fst, DotCloudA},
                                  ordsets:from_list(orddict:fetch_keys(DataStoreB))),
     MergedDataStore =
         ordsets:fold(fun(Object, MergedDataStore0) ->
-                             {ok, SubDataStoreA} = get_data_store(Object, Fst),
-                             {ok, SubDataStoreB} = get_data_store(Object, Snd),
+                             {ok, SubDataStoreA} = get_sub_data_store(Object, Fst),
+                             {ok, SubDataStoreB} = get_sub_data_store(Object, Snd),
                              {MergedSubDataStore, _} =
                                  causal_join({SubDataStoreA, DotCloudA},
                                              {SubDataStoreB, DotCloudB}),
@@ -223,10 +223,10 @@ is_bottom_data_store({dot_fun, DataStore}) ->
 is_bottom_data_store({{dot_map, _ValueDataStoreType}, DataStore}) ->
     orddict:is_empty(DataStore).
 
-%% @doc Get DataStore pointed by the object from {dot_map, dot_map()}.
--spec get_data_store(term(), {{dot_map, data_store_type()}, dot_map()}) ->
+%% @doc Get SubDataStore pointed by the object from {dot_map, dot_map()}.
+-spec get_sub_data_store(term(), {{dot_map, data_store_type()}, dot_map()}) ->
           {ok, data_store()}.
-get_data_store(Object, {{dot_map, ValueDataStoreType}, DataStore}) ->
+get_sub_data_store(Object, {{dot_map, ValueDataStoreType}, DataStore}) ->
     case orddict:find(Object, DataStore) of
         {ok, SubDataStore} ->
             {ok, SubDataStore};

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -1,0 +1,273 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Common library for causal CRDTs.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(state_causal_type).
+-author("Junghun Yoo <junghun.yoo@cs.ox.ac.uk>").
+
+%% causal_crdt() related.
+-export([new_causal_crdt/1,
+         get_dot_cloud/1,
+         causal_join/2,
+         is_lattice_inflation/2,
+         is_lattice_strict_inflation/2]).
+
+%% dot_cloud() related.
+-export([get_next_dot_context/2,
+         insert_dot_context/2,
+         merge_dot_clouds/2]).
+%% data_store() related.
+-export([new_data_store/1,
+         is_bottom_data_store/1]).
+%% {{dot_map, data_store_type()}, dot_map()} related.
+-export([get_data_store/2,
+         insert_object/3,
+         remove_object/2,
+         get_all_objects/1,
+         get_objects_count/1]).
+
+-export_type([dot_context/0,
+              dot_cloud/0,
+              data_store/0,
+              data_store_type/0,
+              causal_crdt/0]).
+
+-type dot_actor() :: term().
+-type dot_context() :: {dot_actor(), pos_integer()}.
+-type dot_cloud() :: ordsets:ordsets(). %% Set of dot_context()
+-type dot_set() :: dot_cloud().
+-type dot_fun() :: orddict:orddict(). %% dot_context() -> Object
+-type dot_map() :: orddict:orddict(). %% Object -> data_store()
+-type data_store_type() :: dot_set | dot_fun | {dot_map, data_store_type()}.
+-type data_store() :: {dot_set, dot_set()}
+                    | {dot_fun, dot_fun()}
+                    | {{dot_map, data_store_type()}, dot_map()}.
+-type causal_crdt() :: {data_store(), dot_cloud()}.
+
+%% @doc Get the Actor's next DotContext from DotCloud.
+-spec get_next_dot_context(dot_actor(), dot_cloud()) -> dot_context().
+get_next_dot_context(DotActor, DotCloud) ->
+    MaxCounter = ordsets:fold(fun({DotActor0, DotCounter0}, MaxValue0) ->
+                                      case (DotActor0 == DotActor) andalso
+                                              (DotCounter0 > MaxValue0) of
+                                          true ->
+                                              DotCounter0;
+                                          false ->
+                                              MaxValue0
+                                      end
+                              end, 0, DotCloud),
+    {DotActor, MaxCounter + 1}.
+
+%% @doc Insert a dot to DotCloud.
+-spec insert_dot_context(dot_context(), dot_cloud()) -> dot_cloud().
+insert_dot_context(DotContext, DotCloud) ->
+    ordsets:add_element(DotContext, DotCloud).
+
+%% @doc Merge two DotClouds.
+-spec merge_dot_clouds(dot_cloud(), dot_cloud()) -> dot_cloud().
+merge_dot_clouds(DotCloudA, DotCloudB) ->
+    ordsets:union(DotCloudA, DotCloudB).
+
+%% @doc Create an empty CausalCRDT.
+-spec new_causal_crdt(data_store_type()) -> causal_crdt().
+new_causal_crdt(dot_set) ->
+    {{dot_set, ordsets:new()}, ordsets:new()};
+new_causal_crdt(dot_fun) ->
+    {{dot_fun, orddict:new()}, ordsets:new()};
+new_causal_crdt({dot_map, ValueDataStoreType}) ->
+    {{{dot_map, ValueDataStoreType}, orddict:new()}, ordsets:new()}.
+
+%% @doc Get DotCloud from DataStore.
+-spec get_dot_cloud(data_store()) -> dot_cloud().
+get_dot_cloud({dot_set, DataStore}) ->
+    DataStore;
+get_dot_cloud({dot_fun, DataStore}) ->
+    ordsets:from_list(orddict:fetch_keys(DataStore));
+get_dot_cloud({{dot_map, _ValueDataStoreType}, DataStore}) ->
+    orddict:fold(fun(_Object, SubDataStore, DotCloud) ->
+                         ordsets:union(DotCloud, get_dot_cloud(SubDataStore))
+                 end, ordsets:new(), DataStore).
+
+%% @doc Universal causal join for a two CausalCRDTs.
+-spec causal_join(causal_crdt(), causal_crdt()) -> causal_crdt().
+causal_join({DataStore, DotCloud}, {DataStore, DotCloud}) ->
+    {DataStore, DotCloud};
+causal_join({{dot_set, DataStoreA}, DotCloudA},
+            {{dot_set, DataStoreB}, DotCloudB}) ->
+    {{dot_set, ordsets:union([ordsets:intersection(DataStoreA, DataStoreB)] ++
+                             [ordsets:subtract(DataStoreA, DotCloudB)] ++
+                             [ordsets:subtract(DataStoreB, DotCloudA)])},
+     ordsets:union(DotCloudA, DotCloudB)};
+causal_join({{dot_fun, DataStoreA}=_Fst, DotCloudA},
+            {{dot_fun, DataStoreB}=Snd, DotCloudB}) ->
+    DomainSnd = get_dot_cloud(Snd),
+    InterDataStore =
+        orddict:fold(fun(DotContext, Object, {dot_fun, DataStore}) ->
+                             case lists:member(DotContext, DomainSnd) of
+                                 true ->
+                                     {dot_fun, orddict:store(DotContext,
+                                                             Object,
+                                                             DataStore)};
+                                 false ->
+                                     {dot_fun, DataStore}
+                             end
+                     end, new_data_store(dot_fun), DataStoreA),
+    MergedDataStore0 =
+        orddict:fold(fun(DotContext, Object, {dot_fun, DataStore}) ->
+                             case ordsets:is_element(DotContext, DotCloudB) of
+                                 true ->
+                                     {dot_fun, DataStore};
+                                 false ->
+                                     {dot_fun, orddict:store(DotContext,
+                                                             Object,
+                                                             DataStore)}
+                             end
+                     end, InterDataStore, DataStoreA),
+    MergedDataStore1 =
+        orddict:fold(fun(DotContext, Object, {dot_fun, DataStore}) ->
+                             case ordsets:is_element(DotContext, DotCloudA) of
+                                 true ->
+                                     {dot_fun, DataStore};
+                                 false ->
+                                     {dot_fun, orddict:store(DotContext,
+                                                             Object,
+                                                             DataStore)}
+                             end
+                     end, MergedDataStore0, DataStoreB),
+    {MergedDataStore1, ordsets:union(DotCloudA, DotCloudB)};
+causal_join({{{dot_map, ValueDataStoreType}, DataStoreA}=Fst, DotCloudA},
+            {{{dot_map, ValueDataStoreType}, DataStoreB}=Snd, DotCloudB}) ->
+    UnionObjects = ordsets:union(ordsets:from_list(orddict:fetch_keys(DataStoreA)),
+                                 ordsets:from_list(orddict:fetch_keys(DataStoreB))),
+    MergedDataStore =
+        ordsets:fold(fun(Object, MergedDataStore0) ->
+                             {ok, SubDataStoreA} = get_data_store(Object, Fst),
+                             {ok, SubDataStoreB} = get_data_store(Object, Snd),
+                             {MergedSubDataStore, _} =
+                                 causal_join({SubDataStoreA, DotCloudA},
+                                             {SubDataStoreB, DotCloudB}),
+                             case is_bottom_data_store(MergedSubDataStore) of
+                                 true ->
+                                     MergedDataStore0;
+                                 false ->
+                                     insert_object(Object,
+                                                   MergedSubDataStore,
+                                                   MergedDataStore0)
+                             end
+                     end, new_data_store({dot_map, ValueDataStoreType}), UnionObjects),
+    {MergedDataStore, ordsets:union(DotCloudA, DotCloudB)}.
+
+%% @doc Determine if a change for a given causal crdt is an inflation or not.
+%%
+%%      Given a particular causal crdt and two instances of that causal crdt,
+%%      determine if `B(second)' is an inflation of `A(first)'.
+-spec is_lattice_inflation(causal_crdt(), causal_crdt()) -> boolean().
+is_lattice_inflation({_DataStoreA, DotCloudA}, {_DataStoreB, DotCloudB}) ->
+    DotCloudAList = get_maxs_for_all(DotCloudA),
+    DotCloudBList = get_maxs_for_all(DotCloudB),
+    lists:foldl(fun({DotActor, Count}, Acc) ->
+                        case lists:keyfind(DotActor, 1, DotCloudBList) of
+                            false ->
+                                Acc andalso false;
+                            {_DotActor1, Count1} ->
+                                Acc andalso (Count =< Count1)
+                        end
+                end, true, DotCloudAList).
+
+%% @doc Determine if a change for a given causal crdt is a strict inflation or not.
+%%
+%%      Given a particular causal crdt and two instances of that causal crdt,
+%%      determine if `B(second)' is a strict inflation of `A(first)'.
+-spec is_lattice_strict_inflation(causal_crdt(), causal_crdt()) -> boolean().
+is_lattice_strict_inflation(CausalCRDTA, CausalCRDTB) ->
+    is_lattice_inflation(CausalCRDTA, CausalCRDTB) andalso
+        not is_lattice_inflation(CausalCRDTB, CausalCRDTA).
+
+%% @doc Create an empty DataStore.
+new_data_store(dot_set) ->
+    {dot_set, ordsets:new()};
+new_data_store(dot_fun) ->
+    {dot_fun, orddict:new()};
+new_data_store({dot_map, ValueDataStoreType}) ->
+    {{dot_map, ValueDataStoreType}, orddict:new()}.
+
+%% @doc Check whether the DataStore is empty.
+-spec is_bottom_data_store(data_store()) -> boolean().
+is_bottom_data_store({dot_set, DataStore}) ->
+    ordsets:size(DataStore) == 0;
+is_bottom_data_store({dot_fun, DataStore}) ->
+    orddict:is_empty(DataStore);
+is_bottom_data_store({{dot_map, _ValueDataStoreType}, DataStore}) ->
+    orddict:is_empty(DataStore).
+
+%% @doc Get DataStore pointed by the object from {dot_map, dot_map()}.
+-spec get_data_store(term(), {{dot_map, data_store_type()}, dot_map()}) ->
+          {ok, data_store()}.
+get_data_store(Object, {{dot_map, ValueDataStoreType}, DataStore}) ->
+    case orddict:find(Object, DataStore) of
+        {ok, SubDataStore} ->
+            {ok, SubDataStore};
+        error ->
+            {ok, new_data_store(ValueDataStoreType)}
+    end.
+
+%% @doc Insert (key: Object, value: SubDataStore) into {dot_map, dot_map()}.
+-spec insert_object(term(), data_store(), {{dot_map, data_store_type()}, dot_map()}) ->
+          {{dot_map, data_store_type()}, dot_map()}.
+insert_object(Object, SubDataStore, {{dot_map, ValueDataStoreType}, DataStore}) ->
+    {{dot_map, ValueDataStoreType}, orddict:store(Object, SubDataStore, DataStore)}.
+
+%% @doc Remove the Object from DataStore.
+%% The Object has to be in the DataStore. This can be checked by
+%% get_data_store().
+-spec remove_object(term(), {{dot_map, data_store_type()}, dot_map()}) ->
+          {{dot_map, data_store_type()}, dot_map()}.
+remove_object(Object, {{dot_map, ValueDataStoreType}, DataStore}) ->
+    {{dot_map, ValueDataStoreType}, orddict:erase(Object, DataStore)}.
+
+%% @doc Get all Objects from DataStore.
+-spec get_all_objects({{dot_map, data_store_type()}, dot_map()}) -> [term()].
+get_all_objects({{dot_map, _ValueDataStoreType}, DataStore}) ->
+    orddict:fetch_keys(DataStore).
+
+%% @doc Get the number of Objects from DataStore.
+-spec get_objects_count({{dot_map, data_store_type()}, dot_map()}) -> non_neg_integer().
+get_objects_count({{dot_map, _ValueDataStoreType}, DataStore}) ->
+    orddict:size(DataStore).
+
+%% Private
+%% @todo This function can be used for the compressing functionality.
+get_maxs_for_all(DotCloud) ->
+    ordsets:fold(fun({DotActor0, DotCounter0}, MaxList) ->
+                         {Counter, NewList} =
+                             case lists:keytake(DotActor0, 1, MaxList) of
+                                 false ->
+                                     {DotCounter0, MaxList};
+                                 {value, {_DotActor, C}, ModList} ->
+                                     {max(DotCounter0, C), ModList}
+                             end,
+                         [{DotActor0,Counter}|NewList]
+                 end, [], DotCloud).

--- a/src/state_oorset.erl
+++ b/src/state_oorset.erl
@@ -180,7 +180,7 @@ join_decomposition({?TYPE, {{{dot_map, dot_set}, DataStoreDict}, DotCloud0}}) ->
 add_elem_delta(Elem, Actor, {DataStore0, DotCloud0}, {DeltaDataStore0, DeltaDotCloud0}) ->
     NewDotContext = state_causal_type:get_next_dot_context(Actor, DotCloud0),
 
-    {ok, {dot_set, DotSet}} = state_causal_type:get_data_store(Elem, DataStore0),
+    {ok, {dot_set, DotSet}} = state_causal_type:get_sub_data_store(Elem, DataStore0),
     DeltaDotCloud1 = state_causal_type:insert_dot_context(NewDotContext, DotSet),
     DeltaDotCloud = state_causal_type:merge_dot_clouds(DeltaDotCloud0, DeltaDotCloud1),
     DeltaDataStore =
@@ -193,7 +193,7 @@ add_elem_delta(Elem, Actor, {DataStore0, DotCloud0}, {DeltaDataStore0, DeltaDotC
     {ok, {DataStore0, DotCloud}, {DeltaDataStore, DeltaDotCloud}}.
 
 remove_elem_delta(Elem, DataStore, {DeltaDataStore0, DeltaDotCloud0}) ->
-    {ok, SubDataStore} = state_causal_type:get_data_store(Elem, DataStore),
+    {ok, SubDataStore} = state_causal_type:get_sub_data_store(Elem, DataStore),
     case state_causal_type:is_bottom_data_store(SubDataStore) of
         false ->
             DeltaDotCloud = state_causal_type:merge_dot_clouds(

--- a/src/state_oorset.erl
+++ b/src/state_oorset.erl
@@ -1,0 +1,379 @@
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Optimised ORSet CRDT: observed-remove set without tombstones
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(state_oorset).
+-author("Junghun Yoo <junghun.yoo@cs.ox.ac.uk>").
+
+-behaviour(type).
+-behaviour(state_type).
+
+-define(TYPE, ?MODULE).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([new/0, new/1]).
+-export([mutate/3, delta_mutate/3, merge/2]).
+-export([query/1, equal/2, is_inflation/2, is_strict_inflation/2]).
+-export([join_decomposition/1]).
+
+-export_type([state_oorset/0, delta_state_oorset/0, state_oorset_op/0]).
+
+-opaque state_oorset() :: {?TYPE, payload()}.
+-opaque delta_state_oorset() :: {?TYPE, {delta, payload()}}.
+-type delta_or_state() :: state_oorset() | delta_state_oorset().
+-type payload() :: state_causal_type:causal_crdt().
+-type element() :: term().
+-type state_oorset_op() :: {add, element()}
+                         | {add_all, [element()]}
+                         | {rmv, element()}
+                         | {rmv_all, [element()]}.
+
+%% @doc Create a new, empty `state_oorset()'
+-spec new() -> state_oorset().
+new() ->
+    {?TYPE, state_causal_type:new_causal_crdt({dot_map, dot_set})}.
+
+%% @doc Create a new, empty `state_oorset()'
+-spec new([term()]) -> state_oorset().
+new([]) ->
+    new().
+
+%% @doc Mutate a `state_oorset()'.
+-spec mutate(state_oorset_op(), type:id(), state_oorset()) ->
+    {ok, state_oorset()} | {error, {precondition, {not_present, [element()]}}}.
+mutate(Op, Actor, {?TYPE, _ORSet}=CRDT) ->
+    state_type:mutate(Op, Actor, CRDT).
+
+%% @doc Delta-mutate a `state_oorset()'.
+%%      The first argument can be:
+%%          - `{add, element()}'
+%%          - `{rmv, element()}'
+%%      The second argument is the replica id.
+%%      The third argument is the `state_oorset()' to be inflated.
+-spec delta_mutate(state_oorset_op(), type:id(), state_oorset()) ->
+    {ok, delta_state_oorset()} | {error, {precondition, {not_present, element()}}}.
+delta_mutate({add, Elem}, Actor, {?TYPE, ORSet}) ->
+    {ok, _ORSet1, Delta} =
+        add_elem_delta(Elem,
+                       Actor,
+                       ORSet,
+                       {state_causal_type:new_data_store({dot_map, dot_set}), ordsets:new()}),
+    {ok, {?TYPE, {delta, Delta}}};
+
+%% @doc Adds a list of elemenets to `state_oorset()'.
+delta_mutate({add_all, Elems}, Actor, {?TYPE, ORSet}) ->
+    {ok, _ORSet1, Delta} =
+        lists:foldl(fun(Elem, {ok, ORSet0, Delta0}) ->
+                            add_elem_delta(Elem, Actor, ORSet0, Delta0)
+                    end,
+                    {ok, ORSet, {state_causal_type:new_data_store({dot_map, dot_set}), ordsets:new()}},
+                    Elems),
+    {ok, {?TYPE, {delta, Delta}}};
+
+%% @doc Removes a single element in `state_oorset()'.
+%% an empty data store and observed dots for the element.
+delta_mutate({rmv, Elem}, _Actor, {?TYPE, {DataStore0, _DotCloud}}) ->
+    case remove_elem_delta(Elem,
+                           DataStore0,
+                           {state_causal_type:new_data_store({dot_map, dot_set}), ordsets:new()}) of
+        {ok, _DataStore, Delta} -> {ok, {?TYPE, {delta, Delta}}};
+        Error -> Error
+    end;
+
+%% @doc Removes a list of elemenets in `state_oorset()'.
+%% an empty data store and observed dots for all elements in the list.
+delta_mutate({rmv_all, Elems}, _Actor, {?TYPE, {DataStore0, _DotCloud}}) ->
+    case remove_elems_delta(Elems,
+                            DataStore0,
+                            {state_causal_type:new_data_store({dot_map, dot_set}), ordsets:new()}) of
+        {ok, _DataStore, Delta} -> {ok, {?TYPE, {delta, Delta}}};
+        Error -> Error
+    end.
+
+%% @doc Returns the value of the `state_oorset()'.
+%% This value is a set with all the keys (elements) in the data store.
+-spec query(state_oorset()) -> sets:set(element()).
+query({?TYPE, {DataStore, _DotCloud}=_ORSet}) ->
+    Result = state_causal_type:get_all_objects(DataStore),
+    sets:from_list(Result).
+
+%% @doc Merge two `state_oorset()'.
+%% Merging will be handled by the causal_join() in the common library.
+-spec merge(delta_or_state(), delta_or_state()) -> delta_or_state().
+merge({?TYPE, {delta, Delta1}}, {?TYPE, {delta, Delta2}}) ->
+    {?TYPE, DeltaGroup} = ?TYPE:merge({?TYPE, Delta1}, {?TYPE, Delta2}),
+    {?TYPE, {delta, DeltaGroup}};
+merge({?TYPE, {delta, Delta}}, {?TYPE, CRDT}) ->
+    merge({?TYPE, Delta}, {?TYPE, CRDT});
+merge({?TYPE, CRDT}, {?TYPE, {delta, Delta}}) ->
+    merge({?TYPE, Delta}, {?TYPE, CRDT});
+merge({?TYPE, ORSet1}, {?TYPE, ORSet2}) ->
+    ORSet = state_causal_type:causal_join(ORSet1, ORSet2),
+    {?TYPE, ORSet}.
+
+%% @doc Equality for `state_oorset()'.
+%% Since everything is ordered, == should work.
+-spec equal(state_oorset(), state_oorset()) -> boolean().
+equal({?TYPE, ORSet1}, {?TYPE, ORSet2}) ->
+    ORSet1 == ORSet2.
+
+%% @doc Given two `state_oorset()', check if the second is and inflation of the first.
+%% The inflation will be checked by the is_lattice_inflation() in the common library.
+-spec is_inflation(state_oorset(), state_oorset()) -> boolean().
+is_inflation({?TYPE, ORSet1}, {?TYPE, ORSet2}) ->
+    state_causal_type:is_lattice_inflation(ORSet1, ORSet2).
+
+%% @doc Check for strict inflation.
+-spec is_strict_inflation(state_oorset(), state_oorset()) -> boolean().
+is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_strict_inflation(CRDT1, CRDT2).
+
+%% @doc Join decomposition for `state_oorset()'.
+-spec join_decomposition(state_oorset()) -> [state_oorset()].
+join_decomposition({?TYPE, {{{dot_map, dot_set}, DataStoreDict}, DotCloud0}}) ->
+    {DecompList, AccDotCloud} =
+        orddict:fold(fun(Elem, SubDataStore, {DecompList0, AccDotCloud0}) ->
+                             NewDotCloud = state_causal_type:get_dot_cloud(SubDataStore),
+                             NewDataStore =
+                                 state_causal_type:insert_object(Elem,
+                                                                 SubDataStore,
+                                                                 state_causal_type:new_data_store({dot_map, dot_set})),
+                             NewORSet = [{?TYPE, {NewDataStore, NewDotCloud}}],
+                             DecompList1 = lists:append(DecompList0, NewORSet),
+                             {DecompList1, state_causal_type:merge_dot_clouds(AccDotCloud0, NewDotCloud)}
+                     end, {[], ordsets:new()}, DataStoreDict),
+    case ordsets:subtract(DotCloud0, AccDotCloud) of
+        [] ->
+            DecompList;
+        RemovedDotCloud ->
+            lists:append(DecompList,
+                         [{?TYPE, {state_causal_type:new_data_store({dot_map, dot_set}),
+                                   RemovedDotCloud}}])
+    end.
+
+%% Private
+add_elem_delta(Elem, Actor, {DataStore0, DotCloud0}, {DeltaDataStore0, DeltaDotCloud0}) ->
+    NewDotContext = state_causal_type:get_next_dot_context(Actor, DotCloud0),
+
+    {ok, {dot_set, DotSet}} = state_causal_type:get_data_store(Elem, DataStore0),
+    DeltaDotCloud1 = state_causal_type:insert_dot_context(NewDotContext, DotSet),
+    DeltaDotCloud = state_causal_type:merge_dot_clouds(DeltaDotCloud0, DeltaDotCloud1),
+    DeltaDataStore =
+        state_causal_type:insert_object(Elem,
+                                        {dot_set, DeltaDotCloud1},
+                                        DeltaDataStore0),
+
+    DotCloud = state_causal_type:insert_dot_context(NewDotContext, DotCloud0),
+
+    {ok, {DataStore0, DotCloud}, {DeltaDataStore, DeltaDotCloud}}.
+
+remove_elem_delta(Elem, DataStore, {DeltaDataStore0, DeltaDotCloud0}) ->
+    {ok, SubDataStore} = state_causal_type:get_data_store(Elem, DataStore),
+    case state_causal_type:is_bottom_data_store(SubDataStore) of
+        false ->
+            DeltaDotCloud = state_causal_type:merge_dot_clouds(
+                              DeltaDotCloud0,
+                              state_causal_type:get_dot_cloud(SubDataStore)),
+            {ok, DataStore, {DeltaDataStore0, DeltaDotCloud}};
+        true ->
+            {error, {precondition, {not_present, Elem}}}
+    end.
+
+remove_elems_delta([], DataStore, Delta) ->
+    {ok, DataStore, Delta};
+remove_elems_delta([Elem|Rest], DataStore, {DeltaDataStore0, DeltaDotCloud0}) ->
+    case remove_elem_delta(Elem, DataStore, {DeltaDataStore0, DeltaDotCloud0}) of
+        {ok, DataStore, Delta} -> remove_elems_delta(Rest, DataStore, Delta);
+        Error         -> Error
+    end.
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+new_test() ->
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, orddict:new()}, ordsets:new()}}, new()).
+
+query_test() ->
+    Set0 = new(),
+    Set1 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{a, 2}]}}]}, [{a, 1}, {a, 2}]}},
+    ?assertEqual(sets:new(), query(Set0)),
+    ?assertEqual(sets:from_list([<<"a">>]), query(Set1)).
+
+delta_add_test() ->
+    Actor = 1,
+    Set0 = new(),
+    {ok, {?TYPE, {delta, Delta1}}} = delta_mutate({add, <<"a">>}, Actor, Set0),
+    Set1 = merge({?TYPE, Delta1}, Set0),
+    {ok, {?TYPE, {delta, Delta2}}} = delta_mutate({add, <<"a">>}, Actor, Set1),
+    Set2 = merge({?TYPE, Delta2}, Set1),
+    {ok, {?TYPE, {delta, Delta3}}} = delta_mutate({add, <<"b">>}, Actor, Set2),
+    Set3 = merge({?TYPE, Delta3}, Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}}, {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}}, Set1),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}, {1, 2}]}}]}, [{1, 1}, {1, 2}]}}, {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}, {1, 2}]}}]}, [{1, 1}, {1, 2}]}}, Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{1, 3}]}}]}, [{1, 3}]}}, {?TYPE, Delta3}),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}, {1, 2}]}}, {<<"b">>, {dot_set, [{1, 3}]}}]}, [{1, 1}, {1, 2}, {1, 3}]}}, Set3).
+
+add_test() ->
+    Actor = 1,
+    Set0 = new(),
+    {ok, Set1} = mutate({add, <<"a">>}, Actor, Set0),
+    {ok, Set2} = mutate({add, <<"a">>}, Actor, Set1),
+    {ok, Set3} = mutate({add, <<"b">>}, Actor, Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}}, Set1),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}, {1, 2}]}}]}, [{1, 1}, {1, 2}]}}, Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}, {1, 2}]}}, {<<"b">>, {dot_set, [{1, 3}]}}]}, [{1, 1}, {1, 2}, {1, 3}]}}, Set3).
+
+rmv_test() ->
+    Actor = 1,
+    Set0 = new(),
+    {ok, Set1} = mutate({add, <<"a">>}, Actor, Set0),
+    {error, _} = mutate({rmv, <<"b">>}, Actor, Set1),
+    {ok, Set2} = mutate({rmv, <<"a">>}, Actor, Set1),
+    ?assertEqual(sets:new(), query(Set2)).
+
+add_all_test() ->
+    Actor = 1,
+    Set0 = new(),
+    {ok, Set1} = mutate({add_all, []}, Actor, Set0),
+    {ok, Set2} = mutate({add_all, [<<"a">>, <<"b">>]}, Actor, Set0),
+    {ok, Set3} = mutate({add_all, [<<"b">>, <<"c">>]}, Actor, Set2),
+    ?assertEqual(sets:new(), query(Set1)),
+    ?assertEqual(sets:from_list([<<"a">>, <<"b">>]), query(Set2)),
+    ?assertEqual(sets:from_list([<<"a">>, <<"b">>, <<"c">>]), query(Set3)).
+
+remove_all_test() ->
+    Actor = 1,
+    Set0 = new(),
+    {ok, Set1} = mutate({add_all, [<<"a">>, <<"b">>, <<"c">>]}, Actor, Set0),
+    {ok, Set2} = mutate({rmv_all, [<<"a">>, <<"c">>]}, Actor, Set1),
+    {error, _} = mutate({rmv_all, [<<"b">>, <<"d">>]}, Actor, Set2),
+    {ok, Set3} = mutate({rmv_all, [<<"b">>]}, Actor, Set2),
+    ?assertEqual(sets:from_list([<<"b">>]), query(Set2)),
+    ?assertEqual(sets:new(), query(Set3)).
+
+merge_idempontent_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}},
+    Set2 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{2, 1}]}}]}, [{2, 1}]}},
+    Set3 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}]}},
+    Set4 = merge(Set1, Set1),
+    Set5 = merge(Set2, Set2),
+    Set6 = merge(Set3, Set3),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}}, Set4),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{2, 1}]}}]}, [{2, 1}]}}, Set5),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}]}}, Set6).
+
+merge_commutative_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}},
+    Set2 = {?TYPE, {{{dot_map, dot_set}, []}, [{2, 1}]}},
+    Set3 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{4, 1}]}}]}, [{3, 1}, {4, 1}]}},
+    Set4 = merge(Set1, Set2),
+    Set5 = merge(Set2, Set1),
+    Set6 = merge(Set1, Set3),
+    Set7 = merge(Set3, Set1),
+    Set8 = merge(Set2, Set3),
+    Set9 = merge(Set3, Set2),
+    Set10 = merge(Set1, merge(Set2, Set3)),
+    Set1_2 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}, {2, 1}]}},
+    Set1_3 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}, {<<"b">>, {dot_set, [{4, 1}]}}]}, [{1, 1}, {3, 1}, {4, 1}]}},
+    Set2_3 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{4, 1}]}}]}, [{2, 1}, {3, 1}, {4, 1}]}},
+    Set1_2_3 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}, {<<"b">>, {dot_set, [{4, 1}]}}]}, [{1, 1}, {2, 1}, {3, 1}, {4, 1}]}},
+    ?assertEqual(Set1_2, Set4),
+    ?assertEqual(Set1_2, Set5),
+    ?assertEqual(Set1_3, Set6),
+    ?assertEqual(Set1_3, Set7),
+    ?assertEqual(Set2_3, Set8),
+    ?assertEqual(Set2_3, Set9),
+    ?assertEqual(Set1_2_3, Set10).
+
+merge_delta_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}},
+    Delta1 = {?TYPE, {delta, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{2, 1}]}}},
+    Delta2 = {?TYPE, {delta, {{{dot_map, dot_set}, []}, [{3, 1}]}}},
+    Set2 = merge(Delta1, Set1),
+    Set3 = merge(Set1, Delta1),
+    DeltaGroup = merge(Delta1, Delta2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}]}}, Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}]}}, Set3),
+    ?assertEqual({?TYPE, {delta, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{2, 1}, {3, 1}]}}}, DeltaGroup).
+
+equal_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}},
+    Set2 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{2, 1}]}},
+    Set3 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{4, 1}]}}]}, [{3, 1}, {4, 1}]}},
+    ?assert(equal(Set1, Set1)),
+    ?assert(equal(Set2, Set2)),
+    ?assert(equal(Set3, Set3)),
+    ?assertNot(equal(Set1, Set2)),
+    ?assertNot(equal(Set1, Set3)),
+    ?assertNot(equal(Set2, Set3)).
+
+is_inflation_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}},
+    Set2 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}]}},
+    Set3 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{3, 1}]}}]}, [{1, 1}, {3, 1}]}},
+    ?assert(is_inflation(Set1, Set1)),
+    ?assert(is_inflation(Set1, Set2)),
+    ?assertNot(is_inflation(Set2, Set1)),
+    ?assert(is_inflation(Set1, Set3)),
+    ?assertNot(is_inflation(Set2, Set3)),
+    ?assertNot(is_inflation(Set3, Set2)),
+    %% check inflation with merge
+    ?assert(state_type:is_inflation(Set1, Set1)),
+    ?assert(state_type:is_inflation(Set1, Set2)),
+    ?assertNot(state_type:is_inflation(Set2, Set1)),
+    ?assert(state_type:is_inflation(Set1, Set3)),
+    ?assertNot(state_type:is_inflation(Set2, Set3)),
+    ?assertNot(state_type:is_inflation(Set3, Set2)).
+
+is_strict_inflation_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}},
+    Set2 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}]}},
+    Set3 = {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{3, 1}]}}]}, [{1, 1}, {3, 1}]}},
+    ?assertNot(is_strict_inflation(Set1, Set1)),
+    ?assert(is_strict_inflation(Set1, Set2)),
+    ?assertNot(is_strict_inflation(Set2, Set1)),
+    ?assert(is_strict_inflation(Set1, Set3)),
+    ?assertNot(is_strict_inflation(Set2, Set3)),
+    ?assertNot(is_strict_inflation(Set3, Set2)).
+
+join_decomposition_test() ->
+    Set1 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]}, [{1, 1}]}},
+    Set2 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{3, 1}]}}, {<<"b">>, {dot_set, [{2, 1}]}}]}, [{1, 1}, {2, 1}, {3, 1}]}},
+    Decomp1 = join_decomposition(Set1),
+    Decomp2 = join_decomposition(Set2),
+    List = [{?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{3, 1}]}}]}, [{3, 1}]}},
+            {?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{2, 1}]}}]}, [{2, 1}]}},
+            {?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}}],
+    ?assertEqual([Set1], Decomp1),
+    ?assertEqual(lists:sort(List), lists:sort(Decomp2)).
+
+-endif.

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -35,7 +35,8 @@
                       state_orset |
                       state_pair |
                       state_pncounter |
-                      state_twopset.
+                      state_twopset |
+                      state_oorset.
 -type crdt() :: {state_type(), type:payload()}.
 -type delta_crdt() :: {state_type(), {delta, type:payload()}}.
 -type delta_or_state() :: crdt() | delta_crdt().


### PR DESCRIPTION
src/state_causal_type.erl
- Common library for all causal CRDTs
- Based on the design of the 'Delta State Replicated Data Types (2016)'

src/state_oorset.erl
- Implementation for the optimised orset type
- Based on the design of the 'Delta State Replicated Data Types (2016)'
- Current implementation is for an example of the causal CRDTs
- This type will not be used for the Lasp implementation (the optimised orset with the provenance semiring will be)
