### PR TITLE
Allow deltas to be used in inflation checking.

### DIFF
--- a/src/state_bcounter.erl
+++ b/src/state_bcounter.erl
@@ -189,7 +189,9 @@ equal({?TYPE, {PNCounter1, GMap1}}, {?TYPE, {PNCounter2, GMap2}}) ->
 %% @doc Given two `state_bcounter()', check if the second is an
 %%      inflation of the first.
 %%      We have and inflation if we have an inflation component wise.
--spec is_inflation(state_bcounter(), state_bcounter()) -> boolean().
+-spec is_inflation(delta_or_state(), state_bcounter()) -> boolean().
+is_inflation({?TYPE, {delta, BCounter1}}, {?TYPE, BCounter2}) ->
+    is_inflation({?TYPE, BCounter1}, {?TYPE, BCounter2});
 is_inflation({?TYPE, {PNCounter1, GMap1}}, {?TYPE, {PNCounter2, GMap2}}) ->
     ?PNCOUNTER_TYPE:is_inflation(PNCounter1, PNCounter2) andalso
     ?GMAP_TYPE:is_inflation(GMap1, GMap2).
@@ -202,7 +204,9 @@ is_inflation({?TYPE, {PNCounter1, GMap1}}, {?TYPE, {PNCounter2, GMap2}}) ->
 %%      Composition of State-based CRDTs (2015)
 %%      [http://haslab.uminho.pt/cbm/files/crdtcompositionreport.pdf]
 %%
--spec is_strict_inflation(state_bcounter(), state_bcounter()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_bcounter()) -> boolean().
+is_strict_inflation({?TYPE, {delta, BCounter1}}, {?TYPE, BCounter2}) ->
+    is_strict_inflation({?TYPE, BCounter1}, {?TYPE, BCounter2});
 is_strict_inflation({?TYPE, {PNCounter1, GMap1}}, {?TYPE, {PNCounter2, GMap2}}) ->
     (?PNCOUNTER_TYPE:is_strict_inflation(PNCounter1, PNCounter2)
         andalso

--- a/src/state_gcounter.erl
+++ b/src/state_gcounter.erl
@@ -142,7 +142,9 @@ equal({?TYPE, GCounter1}, {?TYPE, GCounter2}) ->
 %%          - the value for each replica in the first `state_gcounter()'
 %%          should be less or equal than the value for the same
 %%          replica in the second `state_gcounter()'
--spec is_inflation(state_gcounter(), state_gcounter()) -> boolean().
+-spec is_inflation(delta_or_state(), state_gcounter()) -> boolean().
+is_inflation({?TYPE, {delta, GCounter1}}, {?TYPE, GCounter2}) ->
+    is_inflation({?TYPE, GCounter1}, {?TYPE, GCounter2});
 is_inflation({?TYPE, GCounter1}, {?TYPE, GCounter2}) ->
     lists_ext:iterate_until(
         fun({Key, Value1}) ->
@@ -163,7 +165,9 @@ is_inflation({value, Value1}, {?TYPE, _}=GCounter) ->
     Value2 >= Value1.
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_gcounter(), state_gcounter()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_gcounter()) -> boolean().
+is_strict_inflation({?TYPE, {delta, GCounter1}}, {?TYPE, GCounter2}) ->
+    is_strict_inflation({?TYPE, GCounter1}, {?TYPE, GCounter2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2);
 
@@ -273,11 +277,14 @@ equal_test() ->
 
 is_inflation_test() ->
     Counter1 = {?TYPE, [{1, 2}, {2, 1}, {4, 1}]},
+    DeltaCounter1 = {?TYPE, {delta, [{1, 2}, {2, 1}, {4, 1}]}},
     Counter2 = {?TYPE, [{1, 2}, {2, 1}, {4, 1}, {5, 6}]},
     Counter3 = {?TYPE, [{1, 2}, {2, 2}, {4, 1}]},
     Counter4 = {?TYPE, [{1, 2}, {2, 1}]},
     ?assert(is_inflation(Counter1, Counter1)),
     ?assert(is_inflation(Counter1, Counter2)),
+    ?assert(is_inflation(DeltaCounter1, Counter1)),
+    ?assert(is_inflation(DeltaCounter1, Counter2)),
     ?assert(is_inflation(Counter1, Counter3)),
     ?assertNot(is_inflation(Counter1, Counter4)),
     %% check inflation with merge
@@ -288,11 +295,14 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Counter1 = {?TYPE, [{1, 2}, {2, 1}, {4, 1}]},
+    DeltaCounter1 = {?TYPE, {delta, [{1, 2}, {2, 1}, {4, 1}]}},
     Counter2 = {?TYPE, [{1, 2}, {2, 1}, {4, 1}, {5, 6}]},
     Counter3 = {?TYPE, [{1, 2}, {2, 2}, {4, 1}]},
     Counter4 = {?TYPE, [{1, 2}, {2, 1}]},
     ?assertNot(is_strict_inflation(Counter1, Counter1)),
     ?assert(is_strict_inflation(Counter1, Counter2)),
+    ?assertNot(is_strict_inflation(DeltaCounter1, Counter1)),
+    ?assert(is_strict_inflation(DeltaCounter1, Counter2)),
     ?assert(is_strict_inflation(Counter1, Counter3)),
     ?assertNot(is_strict_inflation(Counter1, Counter4)).
 

--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -143,7 +143,9 @@ equal({?TYPE, {Type, GMap1}}, {?TYPE, {Type, GMap2}}) ->
 %%          - for each key in the first `state_gmap()',
 %%          the correspondent value in the second `state_gmap()'
 %%          should be an inflation of the value in the first.
--spec is_inflation(state_gmap(), state_gmap()) -> boolean().
+-spec is_inflation(delta_or_state(), state_gmap()) -> boolean().
+is_inflation({?TYPE, {delta, {Type, _GMap1}=G1}}, {?TYPE, {Type, _GMap2}=G2}) ->
+    is_inflation({?TYPE, G1}, {?TYPE, G2});
 is_inflation({?TYPE, {Type, GMap1}}, {?TYPE, {Type, GMap2}}) ->
     lists_ext:iterate_until(
         fun({Key, Value1}) ->
@@ -158,7 +160,9 @@ is_inflation({?TYPE, {Type, GMap1}}, {?TYPE, {Type, GMap2}}) ->
      ).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_gmap(), state_gmap()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_gmap()) -> boolean().
+is_strict_inflation({?TYPE, {delta, {Type, _GMap1}=G1}}, {?TYPE, {Type, _GMap2}=G2}) ->
+    is_strict_inflation({?TYPE, G1}, {?TYPE, G2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -232,10 +236,13 @@ equal_test() ->
 
 is_inflation_test() ->
     Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    DeltaMap1 = {?TYPE, {delta, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}},
     Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
     Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     ?assert(is_inflation(Map1, Map1)),
     ?assert(is_inflation(Map1, Map2)),
+    ?assert(is_inflation(DeltaMap1, Map1)),
+    ?assert(is_inflation(DeltaMap1, Map2)),
     ?assertNot(is_inflation(Map1, Map3)),
     %% check inflation with merge
     ?assert(state_type:is_inflation(Map1, Map1)),
@@ -244,10 +251,13 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    DeltaMap1 = {?TYPE, {delta, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}},
     Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
     Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     ?assertNot(is_strict_inflation(Map1, Map1)),
     ?assert(is_strict_inflation(Map1, Map2)),
+    ?assertNot(is_strict_inflation(DeltaMap1, Map1)),
+    ?assert(is_strict_inflation(DeltaMap1, Map2)),
     ?assertNot(is_strict_inflation(Map1, Map3)).
 
 join_decomposition_test() ->

--- a/src/state_gset.erl
+++ b/src/state_gset.erl
@@ -119,12 +119,16 @@ equal({?TYPE, GSet1}, {?TYPE, GSet2}) ->
 %%      of the first.
 %%      The second `state_gset()' is an inflation if the first set is
 %%      a subset of the second.
--spec is_inflation(state_gset(), state_gset()) -> boolean().
+-spec is_inflation(delta_or_state(), state_gset()) -> boolean().
+is_inflation({?TYPE, {delta, GSet1}}, {?TYPE, GSet2}) ->
+    is_inflation({?TYPE, GSet1}, {?TYPE, GSet2});
 is_inflation({?TYPE, GSet1}, {?TYPE, GSet2}) ->
     ordsets:is_subset(GSet1, GSet2).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_gset(), state_gset()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_gset()) -> boolean().
+is_strict_inflation({?TYPE, {delta, GSet1}}, {?TYPE, GSet2}) ->
+    is_strict_inflation({?TYPE, GSet1}, {?TYPE, GSet2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -215,9 +219,12 @@ equal_test() ->
 
 is_inflation_test() ->
     Set1 = {?TYPE, [<<"a">>]},
+    DeltaSet1 = {?TYPE, {delta, [<<"a">>]}},
     Set2 = {?TYPE, [<<"a">>, <<"b">>]},
     ?assert(is_inflation(Set1, Set1)),
     ?assert(is_inflation(Set1, Set2)),
+    ?assert(is_inflation(DeltaSet1, Set1)),
+    ?assert(is_inflation(DeltaSet1, Set2)),
     ?assertNot(is_inflation(Set2, Set1)),
     %% check inflation with merge
     ?assert(state_type:is_inflation(Set1, Set1)),
@@ -226,9 +233,12 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Set1 = {?TYPE, [<<"a">>]},
+    DeltaSet1 = {?TYPE, {delta, [<<"a">>]}},
     Set2 = {?TYPE, [<<"a">>, <<"b">>]},
     ?assertNot(is_strict_inflation(Set1, Set1)),
     ?assert(is_strict_inflation(Set1, Set2)),
+    ?assertNot(is_strict_inflation(DeltaSet1, Set1)),
+    ?assert(is_strict_inflation(DeltaSet1, Set2)),
     ?assertNot(is_strict_inflation(Set2, Set1)).
 
 join_decomposition_test() ->

--- a/src/state_lexcounter.erl
+++ b/src/state_lexcounter.erl
@@ -156,7 +156,9 @@ equal({?TYPE, LexCounter1}, {?TYPE, LexCounter2}) ->
 %%          component of P1
 %%          - their first components are equal and the second component
 %%          of P2 is and inflation of the second component of P1
--spec is_inflation(state_lexcounter(), state_lexcounter()) -> boolean().
+-spec is_inflation(delta_or_state(), state_lexcounter()) -> boolean().
+is_inflation({?TYPE, {delta, LexCounter1}}, {?TYPE, LexCounter2}) ->
+    is_inflation({?TYPE, LexCounter1}, {?TYPE, LexCounter2});
 is_inflation({?TYPE, LexCounter1}, {?TYPE, LexCounter2}) ->
     LexPairInflation = fun({Left1, Right1}, {Left2, Right2}) ->
         (Left2 > Left1)
@@ -176,7 +178,9 @@ is_inflation({?TYPE, LexCounter1}, {?TYPE, LexCounter2}) ->
     ).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_lexcounter(), state_lexcounter()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_lexcounter()) -> boolean().
+is_strict_inflation({?TYPE, {delta, LexCounter1}}, {?TYPE, LexCounter2}) ->
+    is_strict_inflation({?TYPE, LexCounter1}, {?TYPE, LexCounter2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -259,12 +263,15 @@ equal_test() ->
 
 is_inflation_test() ->
     Counter1 = {?TYPE, [{<<"1">>, {2, 0}}]},
+    DeltaCounter1 = {?TYPE, {delta, [{<<"1">>, {2, 0}}]}},
     Counter2 = {?TYPE, [{<<"1">>, {2, 0}}, {<<"2">>, {1, -1}}]},
     Counter3 = {?TYPE, [{<<"1">>, {2, 1}}]},
     Counter4 = {?TYPE, [{<<"1">>, {3, -2}}]},
     Counter5 = {?TYPE, [{<<"1">>, {2, -1}}]},
     ?assert(is_inflation(Counter1, Counter1)),
     ?assert(is_inflation(Counter1, Counter2)),
+    ?assert(is_inflation(DeltaCounter1, Counter1)),
+    ?assert(is_inflation(DeltaCounter1, Counter2)),
     ?assertNot(is_inflation(Counter2, Counter1)),
     ?assert(is_inflation(Counter1, Counter3)),
     ?assert(is_inflation(Counter1, Counter4)),
@@ -279,12 +286,15 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Counter1 = {?TYPE, [{<<"1">>, {2, 0}}]},
+    DeltaCounter1 = {?TYPE, {delta, [{<<"1">>, {2, 0}}]}},
     Counter2 = {?TYPE, [{<<"1">>, {2, 0}}, {<<"2">>, {1, -1}}]},
     Counter3 = {?TYPE, [{<<"1">>, {2, 1}}]},
     Counter4 = {?TYPE, [{<<"1">>, {3, -2}}]},
     Counter5 = {?TYPE, [{<<"1">>, {2, -1}}]},
     ?assertNot(is_strict_inflation(Counter1, Counter1)),
     ?assert(is_strict_inflation(Counter1, Counter2)),
+    ?assertNot(is_strict_inflation(DeltaCounter1, Counter1)),
+    ?assert(is_strict_inflation(DeltaCounter1, Counter2)),
     ?assertNot(is_strict_inflation(Counter2, Counter1)),
     ?assert(is_strict_inflation(Counter1, Counter3)),
     ?assert(is_strict_inflation(Counter1, Counter4)),

--- a/src/state_max_int.erl
+++ b/src/state_max_int.erl
@@ -101,12 +101,16 @@ equal({?TYPE, Value1}, {?TYPE, Value2}) ->
 %%      of the first.
 %%      The second is an inflation if its value is greater or equal
 %%      to the value of the first.
--spec is_inflation(state_max_int(), state_max_int()) -> boolean().
+-spec is_inflation(delta_or_state(), state_max_int()) -> boolean().
+is_inflation({?TYPE, {delta, Value1}}, {?TYPE, Value2}) ->
+    is_inflation({?TYPE, Value1}, {?TYPE, Value2});
 is_inflation({?TYPE, Value1}, {?TYPE, Value2}) ->
     Value1 =< Value2.
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_max_int(), state_max_int()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_max_int()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Value1}}, {?TYPE, Value2}) ->
+    is_strict_inflation({?TYPE, Value1}, {?TYPE, Value2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -184,9 +188,12 @@ equal_test() ->
 
 is_inflation_test() ->
     MaxInt1 = {?TYPE, 23},
+    DeltaMaxInt1 = {?TYPE, {delta, 23}},
     MaxInt2 = {?TYPE, 42},
     ?assert(is_inflation(MaxInt1, MaxInt1)),
     ?assert(is_inflation(MaxInt1, MaxInt2)),
+    ?assert(is_inflation(DeltaMaxInt1, MaxInt1)),
+    ?assert(is_inflation(DeltaMaxInt1, MaxInt2)),
     ?assertNot(is_inflation(MaxInt2, MaxInt1)),
     %% check inflation with merge
     ?assert(state_type:is_inflation(MaxInt1, MaxInt1)),
@@ -195,9 +202,12 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     MaxInt1 = {?TYPE, 23},
+    DeltaMaxInt1 = {?TYPE, {delta, 23}},
     MaxInt2 = {?TYPE, 42},
     ?assertNot(is_strict_inflation(MaxInt1, MaxInt1)),
     ?assert(is_strict_inflation(MaxInt1, MaxInt2)),
+    ?assertNot(is_strict_inflation(DeltaMaxInt1, MaxInt1)),
+    ?assert(is_strict_inflation(DeltaMaxInt1, MaxInt2)),
     ?assertNot(is_strict_inflation(MaxInt2, MaxInt1)).
 
 join_decomposition_test() ->

--- a/src/state_orset.erl
+++ b/src/state_orset.erl
@@ -247,7 +247,9 @@ is_inflation({?TYPE, ORSet1}, {?TYPE, ORSet2}) ->
     ).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_orset(), state_orset()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_orset()) -> boolean().
+is_strict_inflation({?TYPE, {delta, ORSet1}}, {?TYPE, ORSet2}) ->
+    is_strict_inflation({?TYPE, ORSet1}, {?TYPE, ORSet2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -398,6 +400,7 @@ is_inflation_test() ->
     Set3 = {?TYPE, [{<<"a">>, [{<<"token1">>, true}]}, {<<"b">>, [{<<"token2">>, false}]}]},
     ?assert(is_inflation(Set1, Set1)),
     ?assert(is_inflation(Set1, Set2)),
+    ?assert(is_inflation(DeltaSet1, Set1)),
     ?assert(is_inflation(DeltaSet1, Set2)),
     ?assertNot(is_inflation(Set2, Set1)),
     ?assert(is_inflation(Set1, Set3)),
@@ -416,9 +419,9 @@ is_strict_inflation_test() ->
     DeltaSet1 = {?TYPE, {delta, [{<<"a">>, [{<<"token1">>, true}]}]}},
     Set2 = {?TYPE, [{<<"a">>, [{<<"token1">>, false}]}]},
     Set3 = {?TYPE, [{<<"a">>, [{<<"token1">>, true}]}, {<<"b">>, [{<<"token2">>, false}]}]},
-    ?assert(is_strict_inflation(DeltaSet1, Set1)),
     ?assertNot(is_strict_inflation(Set1, Set1)),
     ?assert(is_strict_inflation(Set1, Set2)),
+    ?assertNot(is_strict_inflation(DeltaSet1, Set1)),
     ?assert(is_strict_inflation(DeltaSet1, Set2)),
     ?assertNot(is_strict_inflation(Set2, Set1)),
     ?assert(is_strict_inflation(Set1, Set3)),

--- a/src/state_orset.erl
+++ b/src/state_orset.erl
@@ -211,7 +211,9 @@ equal({?TYPE, ORSet1}, {?TYPE, ORSet2}) ->
 %%          - active on both
 %%          - inactive on both
 %%          - first active and second inactive
--spec is_inflation(state_orset(), state_orset()) -> boolean().
+-spec is_inflation(delta_or_state(), state_orset()) -> boolean().
+is_inflation({?TYPE, {delta, ORSet1}}, {?TYPE, ORSet2}) ->
+    is_inflation({?TYPE, ORSet1}, {?TYPE, ORSet2});
 is_inflation({?TYPE, ORSet1}, {?TYPE, ORSet2}) ->
     lists_ext:iterate_until(
         fun({Elem, Tokens1}) ->
@@ -391,10 +393,12 @@ equal_test() ->
 
 is_inflation_test() ->
     Set1 = {?TYPE, [{<<"a">>, [{<<"token1">>, true}]}]},
+    DeltaSet1 = {?TYPE, {delta, [{<<"a">>, [{<<"token1">>, true}]}]}},
     Set2 = {?TYPE, [{<<"a">>, [{<<"token1">>, false}]}]},
     Set3 = {?TYPE, [{<<"a">>, [{<<"token1">>, true}]}, {<<"b">>, [{<<"token2">>, false}]}]},
     ?assert(is_inflation(Set1, Set1)),
     ?assert(is_inflation(Set1, Set2)),
+    ?assert(is_inflation(DeltaSet1, Set2)),
     ?assertNot(is_inflation(Set2, Set1)),
     ?assert(is_inflation(Set1, Set3)),
     ?assertNot(is_inflation(Set2, Set3)),
@@ -409,10 +413,13 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Set1 = {?TYPE, [{<<"a">>, [{<<"token1">>, true}]}]},
+    DeltaSet1 = {?TYPE, {delta, [{<<"a">>, [{<<"token1">>, true}]}]}},
     Set2 = {?TYPE, [{<<"a">>, [{<<"token1">>, false}]}]},
     Set3 = {?TYPE, [{<<"a">>, [{<<"token1">>, true}]}, {<<"b">>, [{<<"token2">>, false}]}]},
+    ?assert(is_strict_inflation(DeltaSet1, Set1)),
     ?assertNot(is_strict_inflation(Set1, Set1)),
     ?assert(is_strict_inflation(Set1, Set2)),
+    ?assert(is_strict_inflation(DeltaSet1, Set2)),
     ?assertNot(is_strict_inflation(Set2, Set1)),
     ?assert(is_strict_inflation(Set1, Set3)),
     ?assertNot(is_strict_inflation(Set2, Set3)),

--- a/src/state_pair.erl
+++ b/src/state_pair.erl
@@ -140,7 +140,9 @@ equal({?TYPE, {{FstType, _}=Fst1, {SndType, _}=Snd1}},
 
 %% @doc Check for `state_pair()' inflation.
 %%      We have an inflation when both of the components are inflations.
--spec is_inflation(state_pair(), state_pair()) -> boolean().
+-spec is_inflation(delta_or_state(), state_pair()) -> boolean().
+is_inflation({?TYPE, {delta, Delta}}, {?TYPE, CRDT}) ->
+    is_inflation({?TYPE, Delta}, {?TYPE, CRDT});
 is_inflation({?TYPE, {{FstType, _}=Fst1, {SndType, _}=Snd1}},
              {?TYPE, {{FstType, _}=Fst2, {SndType, _}=Snd2}}) ->
     FstType:is_inflation(Fst1, Fst2) andalso
@@ -154,7 +156,9 @@ is_inflation({?TYPE, {{FstType, _}=Fst1, {SndType, _}=Snd1}},
 %%      Composition of State-based CRDTs (2015)
 %%      [http://haslab.uminho.pt/cbm/files/crdtcompositionreport.pdf]
 %%
--spec is_strict_inflation(state_pair(), state_pair()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_pair()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Delta}}, {?TYPE, CRDT}) ->
+    is_strict_inflation({?TYPE, Delta}, {?TYPE, CRDT});
 is_strict_inflation({?TYPE, {{FstType, _}=Fst1, {SndType, _}=Snd1}},
                     {?TYPE, {{FstType, _}=Fst2, {SndType, _}=Snd2}}) ->
     (FstType:is_strict_inflation(Fst1, Fst2) andalso SndType:is_inflation(Snd1, Snd2))
@@ -241,11 +245,14 @@ is_inflation_test() ->
     GSet1 = {?GSET_TYPE, [<<"a">>]},
     GSet2 = {?GSET_TYPE, [<<"b">>]},
     Pair1 = {?TYPE, {GCounter1, GSet1}},
+    DeltaPair1 = {?TYPE, {delta, {GCounter1, GSet1}}},
     Pair2 = {?TYPE, {GCounter1, GSet2}},
     Pair3 = {?TYPE, {GCounter1, GSet1}},
     Pair4 = {?TYPE, {GCounter2, GSet1}},
     ?assert(is_inflation(Pair1, Pair1)),
     ?assertNot(is_inflation(Pair1, Pair2)),
+    ?assert(is_inflation(DeltaPair1, Pair1)),
+    ?assertNot(is_inflation(DeltaPair1, Pair2)),
     ?assert(is_inflation(Pair3, Pair4)),
     %% check inflation with merge
     ?assert(state_type:is_inflation(Pair1, Pair1)),
@@ -258,11 +265,15 @@ is_strict_inflation_test() ->
     GSet1 = {?GSET_TYPE, [<<"a">>]},
     GSet2 = {?GSET_TYPE, [<<"b">>]},
     Pair1 = {?TYPE, {GCounter1, GSet1}},
+    DeltaPair1 = {?TYPE, {delta, {GCounter1, GSet1}}},
+    Pair2 = {?TYPE, {GCounter1, GSet2}},
     Pair2 = {?TYPE, {GCounter1, GSet2}},
     Pair3 = {?TYPE, {GCounter1, GSet1}},
     Pair4 = {?TYPE, {GCounter2, GSet1}},
     ?assertNot(is_strict_inflation(Pair1, Pair1)),
     ?assertNot(is_strict_inflation(Pair1, Pair2)),
+    ?assertNot(is_strict_inflation(DeltaPair1, Pair1)),
+    ?assertNot(is_strict_inflation(DeltaPair1, Pair2)),
     ?assert(is_strict_inflation(Pair3, Pair4)),
     ?assertNot(is_strict_inflation(Pair2, Pair4)).
 

--- a/src/state_pncounter.erl
+++ b/src/state_pncounter.erl
@@ -161,7 +161,9 @@ equal({?TYPE, PNCounter1}, {?TYPE, PNCounter2}) ->
 %%          - component wise the value for each replica in the first
 %%          `state_pncounter()' should be less or equal than the value
 %%          for the same replica in the second `state_pncounter()'
--spec is_inflation(state_pncounter(), state_pncounter()) -> boolean().
+-spec is_inflation(delta_or_state(), state_pncounter()) -> boolean().
+is_inflation({?TYPE, {delta, PNCounter1}}, {?TYPE, PNCounter2}) ->
+    is_inflation({?TYPE, PNCounter1}, {?TYPE, PNCounter2});
 is_inflation({?TYPE, PNCounter1}, {?TYPE, PNCounter2}) ->
     lists_ext:iterate_until(
         fun({Key, {Inc1, Dec1}}) ->
@@ -176,7 +178,9 @@ is_inflation({?TYPE, PNCounter1}, {?TYPE, PNCounter2}) ->
      ).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_pncounter(), state_pncounter()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_pncounter()) -> boolean().
+is_strict_inflation({?TYPE, {delta, PNCounter1}}, {?TYPE, PNCounter2}) ->
+    is_strict_inflation({?TYPE, PNCounter1}, {?TYPE, PNCounter2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -286,11 +290,14 @@ equal_test() ->
 
 is_inflation_test() ->
     Counter1 = {?TYPE, [{1, {2, 0}}, {2, {1, 2}}, {4, {1, 2}}]},
+    DeltaCounter1 = {?TYPE, {delta, [{1, {2, 0}}, {2, {1, 2}}, {4, {1, 2}}]}},
     Counter2 = {?TYPE, [{1, {2, 0}}, {2, {1, 2}}, {4, {1, 2}}, {5, {6, 3}}]},
     Counter3 = {?TYPE, [{1, {2, 0}}, {2, {2, 2}}, {4, {1, 2}}]},
     Counter4 = {?TYPE, [{1, {2, 1}}, {2, {1, 1}}, {4, {1, 2}}]},
     ?assert(is_inflation(Counter1, Counter1)),
     ?assert(is_inflation(Counter1, Counter2)),
+    ?assert(is_inflation(DeltaCounter1, Counter1)),
+    ?assert(is_inflation(DeltaCounter1, Counter2)),
     ?assert(is_inflation(Counter1, Counter3)),
     ?assertNot(is_inflation(Counter1, Counter4)),
     %% check inflation with merge
@@ -301,11 +308,14 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Counter1 = {?TYPE, [{1, {2, 0}}, {2, {1, 2}}, {4, {1, 2}}]},
+    DeltaCounter1 = {?TYPE, {delta, [{1, {2, 0}}, {2, {1, 2}}, {4, {1, 2}}]}},
     Counter2 = {?TYPE, [{1, {2, 0}}, {2, {1, 2}}, {4, {1, 2}}, {5, {6, 3}}]},
     Counter3 = {?TYPE, [{1, {2, 0}}, {2, {2, 2}}, {4, {1, 2}}]},
     Counter4 = {?TYPE, [{1, {2, 1}}, {2, {1, 1}}, {4, {1, 2}}]},
     ?assertNot(is_strict_inflation(Counter1, Counter1)),
     ?assert(is_strict_inflation(Counter1, Counter2)),
+    ?assertNot(is_strict_inflation(DeltaCounter1, Counter1)),
+    ?assert(is_strict_inflation(DeltaCounter1, Counter2)),
     ?assert(is_strict_inflation(Counter1, Counter3)),
     ?assertNot(is_strict_inflation(Counter1, Counter4)).
 

--- a/src/state_twopset.erl
+++ b/src/state_twopset.erl
@@ -133,13 +133,17 @@ equal({?TYPE, {Added1, Removed1}}, {?TYPE, {Added2, Removed2}}) ->
 %%      The second `state_twopset()' is an inflation if the first set
 %%      with adds is a subset of the second with adds.
 %%      Vice versa for the sets with removes.
--spec is_inflation(state_twopset(), state_twopset()) -> boolean().
+-spec is_inflation(delta_or_state(), state_twopset()) -> boolean().
+is_inflation({?TYPE, {delta, Set1}}, {?TYPE, Set2}) ->
+    is_inflation({?TYPE, Set1}, {?TYPE, Set2});
 is_inflation({?TYPE, {Added1, Removed1}}, {?TYPE, {Added2, Removed2}}) ->
     ordsets:is_subset(Added1, Added2) andalso
     ordsets:is_subset(Removed1, Removed2).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_twopset(), state_twopset()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_twopset()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Set1}}, {?TYPE, Set2}) ->
+    is_strict_inflation({?TYPE, Set1}, {?TYPE, Set2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
@@ -232,10 +236,13 @@ equal_test() ->
 
 is_inflation_test() ->
     Set1 = {?TYPE, {[<<"a">>], []}},
+    DeltaSet1 = {?TYPE, {delta, {[<<"a">>], []}}},
     Set2 = {?TYPE, {[<<"a">>], [<<"b">>]}},
     Set3 = {?TYPE, {[<<"a">>, <<"b">>], []}},
     ?assert(is_inflation(Set1, Set1)),
     ?assert(is_inflation(Set1, Set2)),
+    ?assert(is_inflation(DeltaSet1, Set1)),
+    ?assert(is_inflation(DeltaSet1, Set2)),
     ?assertNot(is_inflation(Set2, Set1)),
     ?assert(is_inflation(Set1, Set3)),
     ?assertNot(is_inflation(Set2, Set3)),
@@ -248,10 +255,13 @@ is_inflation_test() ->
 
 is_strict_inflation_test() ->
     Set1 = {?TYPE, {[<<"a">>], []}},
+    DeltaSet1 = {?TYPE, {delta, {[<<"a">>], []}}},
     Set2 = {?TYPE, {[<<"a">>], [<<"b">>]}},
     Set3 = {?TYPE, {[<<"a">>, <<"b">>], []}},
     ?assertNot(is_strict_inflation(Set1, Set1)),
     ?assert(is_strict_inflation(Set1, Set2)),
+    ?assertNot(is_strict_inflation(DeltaSet1, Set1)),
+    ?assert(is_strict_inflation(DeltaSet1, Set2)),
     ?assertNot(is_strict_inflation(Set2, Set1)),
     ?assert(is_strict_inflation(Set1, Set3)),
     ?assertNot(is_strict_inflation(Set2, Set3)).

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -51,8 +51,8 @@
 -callback merge(delta_or_state(), delta_or_state()) -> delta_or_state().
 
 %% Inflation testing.
--callback is_inflation(crdt(), crdt()) -> boolean().
--callback is_strict_inflation(crdt(), crdt()) -> boolean().
+-callback is_inflation(delta_or_state(), crdt()) -> boolean().
+-callback is_strict_inflation(delta_or_state(), crdt()) -> boolean().
 
 %% Join decomposition.
 -callback join_decomposition(crdt()) -> [crdt()].


### PR DESCRIPTION
Sometimes, to ensure read-your-own-writes consistency, you want to generate a delta mutation and ensure the next full state you read is an inflation of that.  Allow deltas to be used in comparison.
