### PR TITLE
Add missing Causal CRDTs and a LWWRegister

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ ebin/*
 dev
 include/*.swp
 src/*.swp
+test/*.swp
 src/.DS_Store
 .DS_Store
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 deps/*
 ebin/*
 dev
+include/*.swp
 src/*.swp
 src/.DS_Store
 .DS_Store

--- a/include/state_type.hrl
+++ b/include/state_type.hrl
@@ -7,6 +7,7 @@
 -define(IVAR_TYPE, state_ivar).
 -define(MAX_INT_TYPE, state_max_int).
 -define(ORSET_TYPE, state_orset).
+-define(ORMAP_TYPE, state_ormap).
 -define(PAIR_TYPE, state_pair).
 -define(PNCOUNTER_TYPE, state_pncounter).
 -define(TWOPSET_TYPE, state_twopset).

--- a/include/state_type.hrl
+++ b/include/state_type.hrl
@@ -1,3 +1,4 @@
+-define(AWSET_TYPE, state_awset).
 -define(BCOUNTER_TYPE, state_bcounter).
 -define(BOOLEAN_TYPE, state_boolean).
 -define(GCOUNTER_TYPE, state_gcounter).

--- a/src/async_iterate.erl
+++ b/src/async_iterate.erl
@@ -1,6 +1,5 @@
-%% -------------------------------------------------------------------
 %%
-%% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/causal_context.erl
+++ b/src/causal_context.erl
@@ -1,7 +1,5 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/causal_context.erl
+++ b/src/causal_context.erl
@@ -1,0 +1,90 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Causal Context.
+%%      The current implementation does not have any optimisations such as
+%%      the causal context compression.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(causal_context).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-export([new/0,
+         merge/2,
+         add_dot/2,
+         max_dot/2,
+         next_dot/2,
+         to_dot_set/1]).
+
+-export_type([causal_context/0]).
+
+-type causal_context() :: orddsets:ordset(dot_store:dot()).
+
+%% @doc Create an empty Causal Context.
+-spec new() -> causal_context().
+new() ->
+    ordsets:new().
+
+%% @doc Merge two Causal Contexts.
+-spec merge(causal_context(), causal_context()) -> causal_context().
+merge(CausalContextA, CausalContextB) ->
+    ordsets:union(CausalContextA, CausalContextB).
+
+-spec add_dot(dot_store:dot(), causal_context()) -> causal_context().
+add_dot(Dot, CausalContext) ->
+    ordsets:add_element(Dot, CausalContext).
+
+%% @doc Get `dot_actor()''s max dot
+-spec max_dot(dot_store:dot_actor(), causal_context()) -> dot_store:dot().
+max_dot(DotActor, CausalContext) ->
+    MaxValue = ordsets:fold(
+        fun({Actor, Value}, CurrentMax) ->
+            case Actor == DotActor andalso Value > CurrentMax of
+                true ->
+                    Value;
+                false ->
+                    CurrentMax
+            end
+        end,
+        0,
+        CausalContext
+    ),
+    {DotActor, MaxValue}.
+
+%% @doc Get `dot_actor()''s next dot
+-spec next_dot(dot_store:dot_actor(), causal_context()) -> dot_store:dot().
+next_dot(DotActor, CausalContext) ->
+    {DotActor, MaxValue} = max_dot(DotActor, CausalContext),
+    {DotActor, MaxValue + 1}.
+
+%% @doc Convert a Causal Context to a DotSet
+-spec to_dot_set(causal_context()) -> dot_store:dot_set().
+to_dot_set(CausalContext) ->
+    ordsets:fold(
+        fun(Dot, DotSet) ->
+            dot_set:add_element(Dot, DotSet)
+        end,
+        dot_set:new(),
+        CausalContext
+    ).

--- a/src/causal_context.erl
+++ b/src/causal_context.erl
@@ -28,6 +28,10 @@
 -module(causal_context).
 -author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([new/0,
          merge/2,
          add_dot/2,

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -1,7 +1,5 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -58,8 +58,8 @@ is_empty({{dot_fun, _CRDTType}, DotFun}) ->
     orddict:is_empty(DotFun).
 
 
-%% DotSet API
-%% @doc Given a Dot and a DotSet, get the correspondent CRDT value.
+%% DotFun API
+%% @doc Given a Dot and a DotFun, get the correspondent CRDT value.
 -spec fetch(dot_store:dot(), dot_store:dot_fun()) -> state_type:crdt().
 fetch(Dot, {{dot_fun, CRDTType}, DotFun}) ->
     {CRDTType, _}=CRDTValue = orddict:fetch(Dot, DotFun),

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -30,6 +30,10 @@
 
 -behaviour(dot_store).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([new/0,
          new/1,
          is_empty/1,

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -1,0 +1,87 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc DotFun.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(dot_fun).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-include("state_type.hrl").
+
+-behaviour(dot_store).
+
+-export([new/0,
+         new/1,
+         is_empty/1,
+         to_causal_context/1]).
+
+% DotFun related (following the same API as `orddict`)
+-export([fetch/2,
+         fetch_keys/1,
+         store/3]).
+
+%% @doc Create an empty DotFun.
+-spec new() -> dot_store:dot_fun().
+new() ->
+    new(?MAX_INT_TYPE).
+
+-spec new(term()) -> dot_store:dot_fun().
+new(CRDTType) ->
+    {{dot_fun, CRDTType}, orddict:new()}.
+
+%% @doc Check if a DotFun is empty.
+-spec is_empty(dot_store:dot_fun()) -> boolean().
+is_empty({{dot_fun, _CRDTType}, DotFun}) ->
+    orddict:is_empty(DotFun).
+
+%% @doc Given a DotFun, extract a Causal Context.
+-spec to_causal_context(dot_store:dot_fun()) -> causal_context:causal_context().
+to_causal_context({{dot_fun, _CRDTType}, DotFun}) ->
+    Dots = orddict:fetch_keys(DotFun),
+    lists:foldl(
+        fun(Dot, CausalContext) ->
+            causal_context:add_dot(Dot, CausalContext)
+        end,
+        causal_context:new(),
+        Dots
+    ).
+
+
+%% DotSet API
+%% @doc Given a Dot and a DotSet, get the correspondent CRDT value.
+-spec fetch(dot_store:dot(), dot_store:dot_fun()) -> state_type:crdt().
+fetch(Dot, {{dot_fun, _CRDTType}, DotFun}) ->
+    {ok, CRDTValue} = orddict:fetch(Dot, DotFun),
+    CRDTValue.
+
+%% @doc Get the list of dots used as keys in the DotFun.
+-spec fetch_keys(dot_store:dot_fun()) -> [term()].
+fetch_keys({{dot_fun, _CRDTType}, DotFun}) ->
+    orddict:fetch_keys(DotFun).
+
+%% @doc Stores a new {Dot, CRDTValue} pair in the DotFun.
+-spec store(dot_store:dot(), state_type:crdt(), dot_store:dot_fun()) -> dot_store:dot_fun().
+store(Dot, {CRDTType, _}=CRDT, {{dot_fun, CRDTType}, DotFun}) ->
+    {{dot_fun, CRDTType}, orddict:store(Dot, CRDT, DotFun)}.

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -38,7 +38,7 @@
          new/1,
          is_empty/1]).
 
-% DotFun related (following the same API as `orddict`)
+% DotFun related (following the same API as `orddict')
 -export([fetch/2,
          fetch_keys/1,
          store/3]).

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -70,8 +70,8 @@ to_causal_context({{dot_fun, _CRDTType}, DotFun}) ->
 %% DotSet API
 %% @doc Given a Dot and a DotSet, get the correspondent CRDT value.
 -spec fetch(dot_store:dot(), dot_store:dot_fun()) -> state_type:crdt().
-fetch(Dot, {{dot_fun, _CRDTType}, DotFun}) ->
-    {ok, CRDTValue} = orddict:fetch(Dot, DotFun),
+fetch(Dot, {{dot_fun, CRDTType}, DotFun}) ->
+    {CRDTType, _}=CRDTValue = orddict:fetch(Dot, DotFun),
     CRDTValue.
 
 %% @doc Get the list of dots used as keys in the DotFun.

--- a/src/dot_fun.erl
+++ b/src/dot_fun.erl
@@ -36,8 +36,7 @@
 
 -export([new/0,
          new/1,
-         is_empty/1,
-         to_causal_context/1]).
+         is_empty/1]).
 
 % DotFun related (following the same API as `orddict`)
 -export([fetch/2,
@@ -57,18 +56,6 @@ new(CRDTType) ->
 -spec is_empty(dot_store:dot_fun()) -> boolean().
 is_empty({{dot_fun, _CRDTType}, DotFun}) ->
     orddict:is_empty(DotFun).
-
-%% @doc Given a DotFun, extract a Causal Context.
--spec to_causal_context(dot_store:dot_fun()) -> causal_context:causal_context().
-to_causal_context({{dot_fun, _CRDTType}, DotFun}) ->
-    Dots = orddict:fetch_keys(DotFun),
-    lists:foldl(
-        fun(Dot, CausalContext) ->
-            causal_context:add_dot(Dot, CausalContext)
-        end,
-        causal_context:new(),
-        Dots
-    ).
 
 
 %% DotSet API

--- a/src/dot_map.erl
+++ b/src/dot_map.erl
@@ -28,6 +28,10 @@
 
 -behaviour(dot_store).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([new/0,
          new/1,
          is_empty/1,

--- a/src/dot_map.erl
+++ b/src/dot_map.erl
@@ -89,6 +89,17 @@ fetch(Key, {{dot_map, DotStoreType}, DotMap}) ->
                 CCausalCRDTType ->
                     {CausalCRDTType, Args} = state_type:extract_args(CCausalCRDTType),
                     {CausalCRDTType, {EmptyDotStore, _CC}} = CausalCRDTType:new(Args),
+                    %% DotMap's can only embed DotStore's.
+                    %% For example, an ORMap<K, AWSet<E>>
+                    %% never actually stores an AWSet in the values
+                    %% only the underlying DotStore (and that's why
+                    %% an ORMap can only embed Causal CRDTs)
+                    %% We know that an AWSet is <DotStore, CausalContext>
+                    %% but the CausalContext is not stored per key-value
+                    %% because all the key-value pairs in the ORMap
+                    %% share the same CausalContext.
+                    %% This behaviour can easily be observed in
+                    %% `state_ormap:query/1' function.
                     EmptyDotStore
             end
     end.

--- a/src/dot_map.erl
+++ b/src/dot_map.erl
@@ -81,9 +81,16 @@ fetch(Key, {{dot_map, DotStoreType}, DotMap}) ->
         {ok, DotStore} ->
             DotStore;
         error ->
-            %% @todo Support complex/nested types
-            %% See `ctype()' on `state_gmap'
-            DotStoreType:new()
+            case DotStoreType of
+                dot_set ->
+                    dot_set:new();
+                {dot_fun, CRDTType} ->
+                    dot_fun:new(CRDTType);
+                CCausalCRDTType ->
+                    {CausalCRDTType, Args} = state_type:extract_args(CCausalCRDTType),
+                    {CausalCRDTType, {EmptyDotStore, _CC}} = CausalCRDTType:new(Args),
+                    EmptyDotStore
+            end
     end.
 
 %% @doc Get a list of keys in the DotMap.

--- a/src/dot_map.erl
+++ b/src/dot_map.erl
@@ -1,7 +1,5 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/dot_map.erl
+++ b/src/dot_map.erl
@@ -1,0 +1,96 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc DotMap.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(dot_map).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-behaviour(dot_store).
+
+-export([new/0,
+         new/1,
+         is_empty/1,
+         to_causal_context/1]).
+
+%% DotMap related (following the same API as `orddict')
+-export([fetch/2,
+         fetch_keys/1,
+         store/3]).
+
+%% @doc Create an empty DotMap (by default with a DotSet as DotStore in values)
+-spec new() -> dot_store:dot_map().
+new() ->
+    new(dot_set).
+
+%% @doc Create an empty DotMap with a given DotStore type in values
+-spec new(term()) -> dot_store:dot_map().
+new(DotStoreType) ->
+    {{dot_map, DotStoreType}, orddict:new()}.
+
+%% @doc Check if a DotStore is empty.
+-spec is_empty(dot_store:dot_map()) -> boolean().
+is_empty({{dot_map, _DotStoreType}, DotMap}) ->
+    orddict:is_empty(DotMap).
+
+%% @doc Given a DotStore, extract a Causal Context.
+-spec to_causal_context(dot_store:dot_map()) -> causal_context:causal_context().
+to_causal_context({{dot_map, _DotStoreType}, DotMap}) ->
+    orddict:fold(
+        fun(_Key, SubDotStore, CausalContext) ->
+            causal_context:merge(
+                to_causal_context(SubDotStore),
+                CausalContext
+            )
+        end,
+        causal_context:new(),
+        DotMap
+    ).
+
+
+%% DotMap API
+%% @doc Given a key and a DotMap, get the correspondent DotStore.
+%%      If the key is not found, an empty DotStore will be returned.
+-spec fetch(term(), dot_store:dot_map()) -> dot_store:dot_store().
+fetch(Key, {{dot_map, DotStoreType}, DotMap}) ->
+    case orddict:find(Key, DotMap) of
+        {ok, DotStore} ->
+            DotStore;
+        error ->
+            %% @todo Support complex/nested types
+            %% See `ctype()' on `state_gmap'
+            DotStoreType:new()
+    end.
+
+%% @doc Get a list of keys in the DotMap.
+-spec fetch_keys(dot_store:dot_map()) -> [term()].
+fetch_keys({{dot_map, _DotStoreType}, DotMap}) ->
+    orddict:fetch_keys(DotMap).
+
+%% @doc Stores a new {Key, DotStore} pair in the DotMap.
+%%      If `Key` already in the DotMap, then its value is updated.
+-spec store(term(), dot_store:dot_store(), dot_store:dot_map()) -> dot_store:dot_map().
+store(Key, SubDotStore, {{dot_map, DotStoreType}, DotMap}) ->
+    {{dot_map, DotStoreType}, orddict:store(Key, SubDotStore, DotMap)}.

--- a/src/dot_map.erl
+++ b/src/dot_map.erl
@@ -34,8 +34,7 @@
 
 -export([new/0,
          new/1,
-         is_empty/1,
-         to_causal_context/1]).
+         is_empty/1]).
 
 %% DotMap related (following the same API as `orddict')
 -export([fetch/2,
@@ -52,24 +51,10 @@ new() ->
 new(DotStoreType) ->
     {{dot_map, DotStoreType}, orddict:new()}.
 
-%% @doc Check if a DotStore is empty.
+%% @doc Check if a DotMap is empty.
 -spec is_empty(dot_store:dot_map()) -> boolean().
 is_empty({{dot_map, _DotStoreType}, DotMap}) ->
     orddict:is_empty(DotMap).
-
-%% @doc Given a DotStore, extract a Causal Context.
--spec to_causal_context(dot_store:dot_map()) -> causal_context:causal_context().
-to_causal_context({{dot_map, _DotStoreType}, DotMap}) ->
-    orddict:fold(
-        fun(_Key, SubDotStore, CausalContext) ->
-            causal_context:merge(
-                to_causal_context(SubDotStore),
-                CausalContext
-            )
-        end,
-        causal_context:new(),
-        DotMap
-    ).
 
 
 %% DotMap API
@@ -110,7 +95,7 @@ fetch_keys({{dot_map, _DotStoreType}, DotMap}) ->
     orddict:fetch_keys(DotMap).
 
 %% @doc Stores a new {Key, DotStore} pair in the DotMap.
-%%      If `Key` already in the DotMap, then its value is updated.
+%%      If `Key` already in the DotMap, then its value is replaced.
 -spec store(term(), dot_store:dot_store(), dot_store:dot_map()) -> dot_store:dot_map().
 store(Key, SubDotStore, {{dot_map, DotStoreType}, DotMap}) ->
     {{dot_map, DotStoreType}, orddict:store(Key, SubDotStore, DotMap)}.

--- a/src/dot_set.erl
+++ b/src/dot_set.erl
@@ -28,6 +28,10 @@
 
 -behaviour(dot_store).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([new/0,
          new/1,
          is_empty/1,

--- a/src/dot_set.erl
+++ b/src/dot_set.erl
@@ -1,7 +1,5 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/dot_set.erl
+++ b/src/dot_set.erl
@@ -1,0 +1,101 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc DotSet.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(dot_set).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-behaviour(dot_store).
+
+-export([new/0,
+         new/1,
+         is_empty/1,
+         to_causal_context/1]).
+
+%% DotSet related (following the same API as `ordsets`)
+-export([add_element/2,
+         intersection/2,
+         is_element/2,
+         subtract/2,
+         to_list/1,
+         union/2]).
+
+%% @doc Create an empty DotSet.
+-spec new() -> dot_store:dot_set().
+new() ->
+    {dot_set, ordsets:new()}.
+
+-spec new(term()) -> dot_store:dot_set().
+new([]) ->
+    new().
+
+%% @doc Check if a DotSet is empty.
+-spec is_empty(dot_store:dot_set()) -> boolean().
+is_empty({dot_set, DotSet}) ->
+    ordsets:size(DotSet) == 0.
+
+%% @doc Given a DotSet, extract a Causal Context.
+-spec to_causal_context(dot_store:dot_set()) -> causal_context:causal_context().
+to_causal_context({dot_set, DotSet}) ->
+    ordsets:fold(
+        fun(Dot, CausalContext) ->
+            causal_context:add_dot(Dot, CausalContext)
+        end,
+        causal_context:new(),
+        DotSet
+    ).
+
+
+%% DotSet API
+%% @doc Add a Dot to the DotSet.
+-spec add_element(dot_store:dot(), dot_store:dot_set()) -> dot_store:dot_set().
+add_element(Dot, {dot_set, DotSet}) ->
+    {dot_set, ordsets:add_element(Dot, DotSet)}.
+
+%% @doc Intersect two DotSets.
+-spec intersection(dot_store:dot_set(), dot_store:dot_set()) -> dot_store:dot_set().
+intersection({dot_set, DotSetA}, {dot_set, DotSetB}) ->
+    {dot_set, ordsets:intersection(DotSetA, DotSetB)}.
+
+%% @doc Check if a Dot belongs to the DotSet.
+-spec is_element(dot_store:dot(), dot_store:dot_set()) -> boolean().
+is_element(Dot, {dot_set, DotSet}) ->
+    ordsets:is_element(Dot, DotSet).
+
+%% @doc Subtract the second DotSet to the first.
+-spec subtract(dot_store:dot_set(), dot_store:dot_set()) -> dot_store:dot_set().
+subtract({dot_set, DotSetA}, {dot_set, DotSetB}) ->
+    {dot_set, ordsets:subtract(DotSetA, DotSetB)}.
+
+%% @doc Convert a DotSet to a list of Dots
+-spec to_list(dot_store:dot_set()) -> [dot_store:dot()].
+to_list({dot_set, DotSet}) ->
+    ordsets:to_list(DotSet).
+
+%% @doc Union two DotSets.
+-spec union(dot_store:dot_set(), dot_store:dot_set()) -> dot_store:dot_set().
+union({dot_set, DotSetA}, {dot_set, DotSetB}) ->
+    {dot_set, ordsets:union(DotSetA, DotSetB)}.

--- a/src/dot_set.erl
+++ b/src/dot_set.erl
@@ -36,7 +36,7 @@
          new/1,
          is_empty/1]).
 
-%% DotSet related (following the same API as `ordsets`)
+%% DotSet related (following the same API as `ordsets')
 -export([add_element/2,
          intersection/2,
          is_element/2,

--- a/src/dot_set.erl
+++ b/src/dot_set.erl
@@ -34,8 +34,7 @@
 
 -export([new/0,
          new/1,
-         is_empty/1,
-         to_causal_context/1]).
+         is_empty/1]).
 
 %% DotSet related (following the same API as `ordsets`)
 -export([add_element/2,
@@ -58,17 +57,6 @@ new([]) ->
 -spec is_empty(dot_store:dot_set()) -> boolean().
 is_empty({dot_set, DotSet}) ->
     ordsets:size(DotSet) == 0.
-
-%% @doc Given a DotSet, extract a Causal Context.
--spec to_causal_context(dot_store:dot_set()) -> causal_context:causal_context().
-to_causal_context({dot_set, DotSet}) ->
-    ordsets:fold(
-        fun(Dot, CausalContext) ->
-            causal_context:add_dot(Dot, CausalContext)
-        end,
-        causal_context:new(),
-        DotSet
-    ).
 
 
 %% DotSet API

--- a/src/dot_store.erl
+++ b/src/dot_store.erl
@@ -1,0 +1,67 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc DotStores:
+%%       - DotSet
+%%       - DotFun
+%%       - DotMap
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(dot_store).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-export_type([dot_actor/0,
+              dot/0,
+              dot_set/0,
+              dot_fun/0,
+              dot_map/0,
+              type/0]).
+
+-type dot_actor() :: term().
+-type dot() :: {dot_actor(), pos_integer()}.
+
+-type dot_set_payload() :: ordsets:ordset(dot()).
+-type dot_set() :: {dot_set, dot_set_payload()}.
+
+-type dot_fun_payload() :: orddict:orddict(dot(), term()).
+-type dot_fun() :: {{dot_fun, state_type:state_type()}, dot_fun_payload()}.
+
+-type dot_map_payload() :: orddict:orddict(term(), dot_store()).
+-type dot_map() :: {{dot_map, type()}, dot_map_payload()}.
+
+-type type() :: dot_set |
+                {dot_fun, state_type:state_type()} |
+                {dot_map, type()}.
+-type dot_store() :: dot_set() | dot_fun() | dot_map().
+
+
+%% @doc Create an empty DotStore.
+-callback new() -> dot_store().
+-callback new(term()) -> dot_store().
+
+%% @doc Check if a DotStore is empty.
+-callback is_empty(dot_store()) -> boolean().
+
+%% @doc Given a DotStore, extract a Causal Context.
+-callback to_causal_context(dot_store()) -> causal_context:causal_context().

--- a/src/dot_store.erl
+++ b/src/dot_store.erl
@@ -1,7 +1,5 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/dot_store.erl
+++ b/src/dot_store.erl
@@ -61,6 +61,3 @@
 
 %% @doc Check if a DotStore is empty.
 -callback is_empty(dot_store()) -> boolean().
-
-%% @doc Given a DotStore, extract a Causal Context.
--callback to_causal_context(dot_store()) -> causal_context:causal_context().

--- a/src/dot_store.erl
+++ b/src/dot_store.erl
@@ -50,7 +50,8 @@
 
 -type type() :: dot_set |
                 {dot_fun, state_type:state_type()} |
-                {dot_map, type()}.
+                {dot_map, type()} |
+                state_type:state_type().
 -type dot_store() :: dot_set() | dot_fun() | dot_map().
 
 

--- a/src/lists_ext.erl
+++ b/src/lists_ext.erl
@@ -1,7 +1,5 @@
-% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/orddict_ext.erl
+++ b/src/orddict_ext.erl
@@ -1,7 +1,5 @@
-% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/ordsets_ext.erl
+++ b/src/ordsets_ext.erl
@@ -1,7 +1,5 @@
-% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/pure_mvregister.erl
+++ b/src/pure_mvregister.erl
@@ -17,13 +17,13 @@
 %%
 %% -------------------------------------------------------------------
 
-%% @doc Pure MVReg CRDT: pure op-based multi-value register
+%% @doc Pure MVRegister CRDT: pure op-based multi-value register
 %%
 %% @reference Carlos Baquero, Paulo Sérgio Almeida, and Ali Shoker
 %%      Making Operation-based CRDTs Operation-based (2014)
 %%      [http://haslab.uminho.pt/ashoker/files/opbaseddais14.pdf]
 
--module(pure_mvreg).
+-module(pure_mvregister).
 -author("Georges Younes <georges.r.younes@gmail.com>").
 
 -behaviour(type).
@@ -42,25 +42,25 @@
 -export([mutate/3, query/1, equal/2, reset/2]).
 -export([redundant/2, remove_redundant_crystal/2, remove_redundant_polog/2, check_stability/2]).
 
--export_type([pure_mvreg/0, pure_mvreg_op/0]).
+-export_type([pure_mvregister/0, pure_mvregister_op/0]).
 
--opaque pure_mvreg() :: {?TYPE, payload()}.
+-opaque pure_mvregister() :: {?TYPE, payload()}.
 -type payload() :: {pure_type:polog(), []}.
--type pure_mvreg_op() :: {set, string()}.
+-type pure_mvregister_op() :: {set, string()}.
 
-%% @doc Create a new, empty `pure_mvreg()'
--spec new() -> pure_mvreg().
+%% @doc Create a new, empty `pure_mvregister()'
+-spec new() -> pure_mvregister().
 new() ->
     {?TYPE, {orddict:new(), []}}.
 
-%% @doc Create a new, empty `pure_mvreg()'
--spec new([term()]) -> pure_mvreg().
+%% @doc Create a new, empty `pure_mvregister()'
+-spec new([term()]) -> pure_mvregister().
 new([]) ->
     new().
 
-%% @doc Check redundancy `pure_mvreg()'
+%% @doc Check redundancy `pure_mvregister()'
 %% Called in remove_redundant().
--spec redundant({pure_type:id(), pure_mvreg_op()}, {pure_type:id(), pure_mvreg_op()}) ->
+-spec redundant({pure_type:id(), pure_mvregister_op()}, {pure_type:id(), pure_mvregister_op()}) ->
     atom().
 redundant({VV1, {_Op1, _Str1}}, {VV2, {_Op2, _Str2}}) ->
     case pure_trcb:happened_before(VV1, VV2) of
@@ -70,8 +70,8 @@ redundant({VV1, {_Op1, _Str1}}, {VV2, {_Op2, _Str2}}) ->
             ?AA
     end.
 
-%% @doc Removes redundant operations from POLog of `pure_mvreg()'
--spec remove_redundant_polog({pure_type:id(), pure_mvreg_op()}, pure_mvreg()) -> {boolean(), pure_mvreg()}.
+%% @doc Removes redundant operations from POLog of `pure_mvregister()'
+-spec remove_redundant_polog({pure_type:id(), pure_mvregister_op()}, pure_mvregister()) -> {boolean(), pure_mvregister()}.
 remove_redundant_polog({VV1, Op}, {?TYPE, {POLog0, MVReg}}) ->
     case orddict:is_empty(POLog0) of
         true ->
@@ -92,32 +92,32 @@ remove_redundant_polog({VV1, Op}, {?TYPE, {POLog0, MVReg}}) ->
             {Add1, {?TYPE, {POLog1, MVReg}}}
     end.
 
-%% @doc Removes redundant operations from crystal of `pure_mvreg()'
+%% @doc Removes redundant operations from crystal of `pure_mvregister()'
 %% No crystalisation for this one.
--spec remove_redundant_crystal({pure_type:id(), pure_mvreg_op()}, pure_mvreg()) -> {boolean(), pure_mvreg()}.
+-spec remove_redundant_crystal({pure_type:id(), pure_mvregister_op()}, pure_mvregister()) -> {boolean(), pure_mvregister()}.
 remove_redundant_crystal({_VV1, _X}, {?TYPE, {POLog0, MVReg}}) ->
     {true, {?TYPE, {POLog0, MVReg}}}.
 
-%% @doc Checks stable operations and remove them from POLog of `pure_mvreg()'
--spec check_stability(pure_type:id(), pure_mvreg()) -> pure_mvreg().
+%% @doc Checks stable operations and remove them from POLog of `pure_mvregister()'
+-spec check_stability(pure_type:id(), pure_mvregister()) -> pure_mvregister().
 check_stability(_StableVV, {?TYPE, {POLog0, MVReg0}}) ->
     {?TYPE, {POLog0, MVReg0}}.
 
-%% @doc Update a `pure_mvreg()'.
--spec mutate(pure_mvreg_op(), pure_type:id(), pure_mvreg()) ->
-    {ok, pure_mvreg()}.
+%% @doc Update a `pure_mvregister()'.
+-spec mutate(pure_mvregister_op(), pure_type:id(), pure_mvregister()) ->
+    {ok, pure_mvregister()}.
 mutate({Op, Str}, VV, {?TYPE, {POLog, PureMVReg}}) ->
     {_Add, {?TYPE, {POLog0, PureMVReg0}}} = pure_polog:remove_redundant({VV, {Op, Str}}, {?TYPE, {POLog, PureMVReg}}),
     {ok, {?TYPE, {orddict:store(VV, Str, POLog0), PureMVReg0}}}.
 
 %% @doc Clear/reset the state to initial state.
--spec reset(pure_type:id(), pure_mvreg()) -> pure_mvreg().
+-spec reset(pure_type:id(), pure_mvregister()) -> pure_mvregister().
 reset(VV, {?TYPE, _}=CRDT) ->
     pure_type:reset(VV, CRDT).
 
-%% @doc Returns the value of the `pure_mvreg()'.
-%%      This value is a a boolean value in the `pure_mvreg()'.
--spec query(pure_mvreg()) -> [string()].
+%% @doc Returns the value of the `pure_mvregister()'.
+%%      This value is a a boolean value in the `pure_mvregister()'.
+-spec query(pure_mvregister()) -> [string()].
 query({?TYPE, {POLog0, _PureMVReg0}}) ->
     case orddict:is_empty(POLog0) of
         true ->
@@ -127,8 +127,8 @@ query({?TYPE, {POLog0, _PureMVReg0}}) ->
     end.
 
 
-%% @doc Equality for `pure_mvreg()'.
--spec equal(pure_mvreg(), pure_mvreg()) -> boolean().
+%% @doc Equality for `pure_mvregister()'.
+-spec equal(pure_mvregister(), pure_mvregister()) -> boolean().
 equal({?TYPE, {POLog1, _PureMVReg1}}, {?TYPE, {POLog2, _PureMVReg2}}) ->
     Fun = fun(Value1, Value2) -> Value1 == Value2 end,
     orddict_ext:equal(POLog1, POLog2, Fun).

--- a/src/pure_mvregister.erl
+++ b/src/pure_mvregister.erl
@@ -46,7 +46,7 @@
 
 -opaque pure_mvregister() :: {?TYPE, payload()}.
 -type payload() :: {pure_type:polog(), []}.
--type pure_mvregister_op() :: {set, string()}.
+-type pure_mvregister_op() :: {set, term()}.
 
 %% @doc Create a new, empty `pure_mvregister()'
 -spec new() -> pure_mvregister().
@@ -62,7 +62,7 @@ new([]) ->
 %% Called in remove_redundant().
 -spec redundant({pure_type:id(), pure_mvregister_op()}, {pure_type:id(), pure_mvregister_op()}) ->
     atom().
-redundant({VV1, {_Op1, _Str1}}, {VV2, {_Op2, _Str2}}) ->
+redundant({VV1, {_Op1, _Val1}}, {VV2, {_Op2, _Val2}}) ->
     case pure_trcb:happened_before(VV1, VV2) of
         true ->
             ?RA;
@@ -106,9 +106,9 @@ check_stability(_StableVV, {?TYPE, {POLog0, MVReg0}}) ->
 %% @doc Update a `pure_mvregister()'.
 -spec mutate(pure_mvregister_op(), pure_type:id(), pure_mvregister()) ->
     {ok, pure_mvregister()}.
-mutate({Op, Str}, VV, {?TYPE, {POLog, PureMVReg}}) ->
-    {_Add, {?TYPE, {POLog0, PureMVReg0}}} = pure_polog:remove_redundant({VV, {Op, Str}}, {?TYPE, {POLog, PureMVReg}}),
-    {ok, {?TYPE, {orddict:store(VV, Str, POLog0), PureMVReg0}}}.
+mutate({Op, Value}, VV, {?TYPE, {POLog, PureMVReg}}) ->
+    {_Add, {?TYPE, {POLog0, PureMVReg0}}} = pure_polog:remove_redundant({VV, {Op, Value}}, {?TYPE, {POLog, PureMVReg}}),
+    {ok, {?TYPE, {orddict:store(VV, Value, POLog0), PureMVReg0}}}.
 
 %% @doc Clear/reset the state to initial state.
 -spec reset(pure_type:id(), pure_mvregister()) -> pure_mvregister().
@@ -117,13 +117,13 @@ reset(VV, {?TYPE, _}=CRDT) ->
 
 %% @doc Returns the value of the `pure_mvregister()'.
 %%      This value is a a boolean value in the `pure_mvregister()'.
--spec query(pure_mvregister()) -> [string()].
+-spec query(pure_mvregister()) -> [term()].
 query({?TYPE, {POLog0, _PureMVReg0}}) ->
     case orddict:is_empty(POLog0) of
         true ->
             [];
         false ->
-            [Str || {_Key, Str} <- orddict:to_list(POLog0)]
+            [Value || {_Key, Value} <- orddict:to_list(POLog0)]
     end.
 
 

--- a/src/pure_no_compaction.erl
+++ b/src/pure_no_compaction.erl
@@ -93,7 +93,7 @@ query({pure_twopset, {POLog0, _Crystal}}) ->
         POLog0
     ),
     sets:from_list(ordsets:subtract(Add, Rmv));
-query({pure_aworset, {POLog0, _Crystal}}) ->
+query({pure_awset, {POLog0, _Crystal}}) ->
     POLog1 = orddict:fold(
         fun(Key0, {Op0, El0}, Acc0) ->
             case orddict:fold(
@@ -118,7 +118,7 @@ query({pure_aworset, {POLog0, _Crystal}}) ->
         POLog0
     ),
     sets:from_list([El || {_Key, {Op, El}} <- orddict:to_list(POLog1), Op =:= add]);
-query({pure_rworset, {POLog0, _Crystal}}) ->
+query({pure_rwset, {POLog0, _Crystal}}) ->
     POLog1 = orddict:fold(
         fun(Key0, {Op0, El0}, Acc0) ->
             case orddict:fold(
@@ -230,28 +230,28 @@ query({pure_mvreg, {POLog0, _Crystal}}) ->
 -ifdef(TEST).
 
 query_test() ->
-    AWORSet1 = {pure_aworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"c">>}}], []}},
-    AWORSet2 = {pure_aworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"a">>}}], []}},
-    AWORSet3 = {pure_aworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {add, <<"b">>}}], []}},
-    AWORSet4 = {pure_aworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 0}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {rmv, <<"b">>}}], []}},
-    AWORSet5 = {pure_aworset, {[], []}},
-    AWORSet6 = {pure_aworset, {[{[{0, 5}, {1, 1}], {add, <<"a">>}}, {[{0, 6}, {1, 1}], {rmv, <<"a">>}}, {[{0, 1}, {1, 5}], {add, <<"a">>}}], []}},
-    ?assertEqual(sets:from_list([<<"a">>, <<"b">>, <<"c">>]), query(AWORSet1)),
-    ?assertEqual(sets:from_list([<<"a">>, <<"b">>]), query(AWORSet2)),
-    ?assertEqual(sets:from_list([<<"b">>]), query(AWORSet3)),
-    ?assertEqual(sets:from_list([<<"a">>]), query(AWORSet4)),
-    ?assertEqual(sets:from_list([]), query(AWORSet5)),
-    ?assertEqual(sets:from_list([<<"a">>]), query(AWORSet6)),
-    RWORSet1 = {pure_rworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"c">>}}], []}},
-    RWORSet2 = {pure_rworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"a">>}}], []}},
-    RWORSet3 = {pure_rworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {add, <<"b">>}}], []}},
-    RWORSet4 = {pure_rworset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 0}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {rmv, <<"b">>}}], []}},
-    RWORSet5 = {pure_rworset, {[], []}},
-    ?assertEqual(sets:from_list([<<"a">>, <<"b">>, <<"c">>]), query(RWORSet1)),
-    ?assertEqual(sets:from_list([<<"a">>, <<"b">>]), query(RWORSet2)),
-    ?assertEqual(sets:from_list([<<"b">>]), query(RWORSet3)),
-    ?assertEqual(sets:from_list([]), query(RWORSet4)),
-    ?assertEqual(sets:from_list([]), query(RWORSet5)),
+    AWSet1 = {pure_awset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"c">>}}], []}},
+    AWSet2 = {pure_awset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"a">>}}], []}},
+    AWSet3 = {pure_awset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {add, <<"b">>}}], []}},
+    AWSet4 = {pure_awset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 0}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {rmv, <<"b">>}}], []}},
+    AWSet5 = {pure_awset, {[], []}},
+    AWSet6 = {pure_awset, {[{[{0, 5}, {1, 1}], {add, <<"a">>}}, {[{0, 6}, {1, 1}], {rmv, <<"a">>}}, {[{0, 1}, {1, 5}], {add, <<"a">>}}], []}},
+    ?assertEqual(sets:from_list([<<"a">>, <<"b">>, <<"c">>]), query(AWSet1)),
+    ?assertEqual(sets:from_list([<<"a">>, <<"b">>]), query(AWSet2)),
+    ?assertEqual(sets:from_list([<<"b">>]), query(AWSet3)),
+    ?assertEqual(sets:from_list([<<"a">>]), query(AWSet4)),
+    ?assertEqual(sets:from_list([]), query(AWSet5)),
+    ?assertEqual(sets:from_list([<<"a">>]), query(AWSet6)),
+    RWSet1 = {pure_rwset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"c">>}}], []}},
+    RWSet2 = {pure_rwset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {add, <<"b">>}}, {[{0, 2}, {1, 3}], {add, <<"a">>}}], []}},
+    RWSet3 = {pure_rwset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 2}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {add, <<"b">>}}], []}},
+    RWSet4 = {pure_rwset, {[{[{0, 0}, {1, 1}], {add, <<"a">>}}, {[{0, 1}, {1, 0}], {rmv, <<"a">>}}, {[{0, 2}, {1, 3}], {rmv, <<"b">>}}], []}},
+    RWSet5 = {pure_rwset, {[], []}},
+    ?assertEqual(sets:from_list([<<"a">>, <<"b">>, <<"c">>]), query(RWSet1)),
+    ?assertEqual(sets:from_list([<<"a">>, <<"b">>]), query(RWSet2)),
+    ?assertEqual(sets:from_list([<<"b">>]), query(RWSet3)),
+    ?assertEqual(sets:from_list([]), query(RWSet4)),
+    ?assertEqual(sets:from_list([]), query(RWSet5)),
     EWFlag0 = {pure_ewflag, {[{[{0, 0}, {1, 1}], disable}, {[{0, 1}, {1, 2}], disable}, {[{0, 2}, {1, 3}], disable}], []}},
     EWFlag1 = {pure_ewflag, {[{[{0, 0}, {1, 1}], enable}, {[{0, 1}, {1, 2}], enable}, {[{0, 2}, {1, 3}], enable}], []}},
     EWFlag2 = {pure_ewflag, {[{[{0, 0}, {1, 1}], enable}, {[{0, 1}, {1, 0}], disable}], []}},

--- a/src/pure_no_compaction.erl
+++ b/src/pure_no_compaction.erl
@@ -203,7 +203,7 @@ query({pure_dwflag, {POLog0, _Crystal}}) ->
                     true
             end
     end;
-query({pure_mvreg, {POLog0, _Crystal}}) ->
+query({pure_mvregister, {POLog0, _Crystal}}) ->
     POLog1 = orddict:fold(
         fun(Key0, Op0, Acc0) ->
             case orddict:fold(
@@ -276,11 +276,11 @@ query_test() ->
     ?assertEqual(true, query(DWFlag3)),
     ?assertEqual(false, query(DWFlag4)),
     ?assertEqual(true, query(DWFlag5)),
-    MVReg0 = {pure_mvreg, {[{[{0, 1}, {1, 1}], "foo"}], []}},
-    MVReg1 = {pure_mvreg, {[{[{0, 1}, {1, 1}], "foo"}, {[{0, 1}, {1, 2}], "bar"}], []}},
-    MVReg2 = {pure_mvreg, {[{[{0, 2}, {1, 1}], "foo"}, {[{0, 1}, {1, 2}], "bar"}], []}},
-    MVReg3 = {pure_mvreg, {[{[{0, 3}, {1, 4}], "foo"}, {[{0, 1}, {1, 1}], "foo"}, {[{0, 2}, {1, 3}], "bar"}], []}},
-    MVReg4 = {pure_mvreg, {[], []}},
+    MVReg0 = {pure_mvregister, {[{[{0, 1}, {1, 1}], "foo"}], []}},
+    MVReg1 = {pure_mvregister, {[{[{0, 1}, {1, 1}], "foo"}, {[{0, 1}, {1, 2}], "bar"}], []}},
+    MVReg2 = {pure_mvregister, {[{[{0, 2}, {1, 1}], "foo"}, {[{0, 1}, {1, 2}], "bar"}], []}},
+    MVReg3 = {pure_mvregister, {[{[{0, 3}, {1, 4}], "foo"}, {[{0, 1}, {1, 1}], "foo"}, {[{0, 2}, {1, 3}], "bar"}], []}},
+    MVReg4 = {pure_mvregister, {[], []}},
     ?assertEqual(sets:from_list(["foo"]), query(MVReg0)),
     ?assertEqual(sets:from_list(["bar"]), query(MVReg1)),
     ?assertEqual(sets:from_list(["foo", "bar"]), query(MVReg2)),

--- a/src/pure_type.erl
+++ b/src/pure_type.erl
@@ -35,7 +35,7 @@
                      pure_gset |
                      pure_mvregister |
                      pure_pncounter |
-                     pure_rworset |
+                     pure_rwset |
                      pure_twopset.
 -type crdt() :: {pure_type(), payload()}.
 -type payload() :: {polog(), term()}.

--- a/src/pure_type.erl
+++ b/src/pure_type.erl
@@ -28,7 +28,15 @@
 -export([reset/2]).
 
 %% Define some initial types.
--type pure_type() :: pure_gcounter | pure_pncounter | pure_gset | pure_twopset | pure_aworset | pure_rworset | pure_ewflag | pure_dwflag | pure_mvreg.
+-type pure_type() :: pure_aworset |
+                     pure_dwflag |
+                     pure_ewflag |
+                     pure_gcounter |
+                     pure_gset |
+                     pure_mvregister |
+                     pure_pncounter |
+                     pure_rworset |
+                     pure_twopset.
 -type crdt() :: {pure_type(), payload()}.
 -type payload() :: {polog(), term()}.
 -type polog() :: orddict:orddict().

--- a/src/pure_type.erl
+++ b/src/pure_type.erl
@@ -28,7 +28,7 @@
 -export([reset/2]).
 
 %% Define some initial types.
--type pure_type() :: pure_aworset |
+-type pure_type() :: pure_awset |
                      pure_dwflag |
                      pure_ewflag |
                      pure_gcounter |

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -194,12 +194,16 @@ is_bottom({?TYPE, _}=CRDT) ->
 
 %% @doc Given two `state_awset()', check if the second is and inflation of the first.
 %% @todo
--spec is_inflation(state_awset(), state_awset()) -> boolean().
+-spec is_inflation(delta_or_state(), state_awset()) -> boolean().
+is_inflation({?TYPE, {delta, AWSet1}}, {?TYPE, AWSet2}) ->
+    is_inflation({?TYPE, AWSet1}, {?TYPE, AWSet2});
 is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_inflation(CRDT1, CRDT2).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_awset(), state_awset()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_awset()) -> boolean().
+is_strict_inflation({?TYPE, {delta, AWSet1}}, {?TYPE, AWSet2}) ->
+    is_strict_inflation({?TYPE, AWSet1}, {?TYPE, AWSet2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -268,15 +268,8 @@ new_test() ->
 
 query_test() ->
     Set0 = new(),
-    Set1 = {?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{a, 2}]}}]
-            },
-            [{a, 1}, {a, 2}]
-        }
-    },
+    Set1 = {?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{a, 2}]}}]},
+                    [{a, 1}, {a, 2}]}},
     ?assertEqual(sets:new(), query(Set0)),
     ?assertEqual(sets:from_list([<<"a">>]), query(Set1)).
 

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -290,69 +290,31 @@ delta_add_test() ->
     {ok, {?TYPE, {delta, Delta3}}} = delta_mutate({add, <<"b">>}, Actor, Set2),
     Set3 = merge({?TYPE, Delta3}, Set2),
 
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{Actor, 1}]}}]
-            },
-            [{Actor, 1}]
-        }},
-        {?TYPE, Delta1}
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{Actor, 1}]}}]
-            },
-            [{Actor, 1}]
-        }},
-        Set1
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{Actor, 2}]}}]
-            },
-            [{Actor, 1}, {Actor, 2}]
-        }},
-        {?TYPE, Delta2}
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{Actor, 2}]}}]
-            },
-            [{Actor, 1}, {Actor, 2}]
-        }},
-        Set2
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"b">>, {dot_set, [{Actor, 3}]}}]
-            },
-            [{Actor, 3}]
-        }},
-        {?TYPE, Delta3}
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [
-                    {<<"a">>, {dot_set, [{Actor, 2}]}},
-                    {<<"b">>, {dot_set, [{Actor, 3}]}}
-                ]
-            },
-            [{Actor, 1}, {Actor, 2}, {Actor, 3}]
-        }},
-        Set3
-    ).
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 1}]}}]},
+                          [{Actor, 1}]}},
+                 {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 1}]}}]},
+                          [{Actor, 1}]}},
+                 Set1),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 2}]}}]},
+                          [{Actor, 1}, {Actor, 2}]}},
+                 {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 2}]}}]},
+                          [{Actor, 1}, {Actor, 2}]}},
+                 Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"b">>, {dot_set, [{Actor, 3}]}}]},
+                          [{Actor, 3}]}},
+                 {?TYPE, Delta3}),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 2}]}},
+                            {<<"b">>, {dot_set, [{Actor, 3}]}}]},
+                          [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+                 Set3).
 
 add_test() ->
     Actor = 1,
@@ -360,39 +322,20 @@ add_test() ->
     {ok, Set1} = mutate({add, <<"a">>}, Actor, Set0),
     {ok, Set2} = mutate({add, <<"a">>}, Actor, Set1),
     {ok, Set3} = mutate({add, <<"b">>}, Actor, Set2),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{Actor, 1}]}}]
-            },
-            [{Actor, 1}]
-        }},
-        Set1
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [{<<"a">>, {dot_set, [{Actor, 2}]}}]
-            },
-            [{Actor, 1}, {Actor, 2}]
-        }},
-        Set2
-    ),
-    ?assertEqual({?TYPE,
-        {
-            {
-                {dot_map, dot_set},
-                [
-                    {<<"a">>, {dot_set, [{Actor, 2}]}},
-                    {<<"b">>, {dot_set, [{Actor, 3}]}}
-                ]
-            },
-            [{Actor, 1}, {Actor, 2}, {Actor, 3}]
-        }},
-        Set3
-    ).
+
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 1}]}}]},
+                          [{Actor, 1}]}},
+                 Set1),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 2}]}}]},
+                          [{Actor, 1}, {Actor, 2}]}},
+                 Set2),
+    ?assertEqual({?TYPE, {{{dot_map, dot_set},
+                           [{<<"a">>, {dot_set, [{Actor, 2}]}},
+                            {<<"b">>, {dot_set, [{Actor, 3}]}}]},
+                          [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+                 Set3).
 
 rmv_test() ->
     Actor = 1,

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -431,13 +431,9 @@ merge_idempontent_test() ->
     Set4 = merge(Set1, Set1),
     Set5 = merge(Set2, Set2),
     Set6 = merge(Set3, Set3),
-    ?assertEqual({?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}}, Set4),
-    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"b">>, {dot_set, [{2, 1}]}}]},
-                          [{2, 1}]}},
-                 Set5),
-    ?assertEqual({?TYPE, {{{dot_map, dot_set}, [{<<"a">>, {dot_set, [{1, 1}]}}]},
-                          [{1, 1}, {2, 1}]}},
-                 Set6).
+    ?assertEqual(Set1, Set4),
+    ?assertEqual(Set2, Set5),
+    ?assertEqual(Set3, Set6).
 
 merge_commutative_test() ->
     Set1 = {?TYPE, {{{dot_map, dot_set}, []}, [{1, 1}]}},

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -194,8 +194,8 @@ is_bottom({?TYPE, _}=CRDT) ->
 %% @doc Given two `state_awset()', check if the second is and inflation of the first.
 %%      The inflation will be checked by the `is_inflation()` in the common library.
 -spec is_inflation(state_awset(), state_awset()) -> boolean().
-is_inflation({?TYPE, AWSet1}, {?TYPE, AWSet2}) ->
-    state_causal_type:is_inflation(AWSet1, AWSet2).
+is_inflation({?TYPE, _}=AWSet1, {?TYPE, _}=AWSet2) ->
+    state_type:is_inflation(AWSet1, AWSet2).
 
 %% @doc Check for strict inflation.
 -spec is_strict_inflation(state_awset(), state_awset()) -> boolean().

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -103,7 +103,7 @@ delta_mutate({add, Elem}, Actor, {?TYPE, {DotStore, CausalContext}}) ->
     DeltaDotStore = dot_map:store(Elem, DeltaDotSet, EmptyDotMap),
 
     CurrentDotSet = dot_map:fetch(Elem, DotStore),
-    DeltaCausalContext0 = dot_set:to_causal_context(CurrentDotSet),
+    DeltaCausalContext0 = causal_context:to_causal_context(CurrentDotSet),
     DeltaCausalContext1 = causal_context:add_dot(NextDot, DeltaCausalContext0),
 
     Delta = {DeltaDotStore, DeltaCausalContext1},
@@ -132,7 +132,7 @@ delta_mutate({rmv, Elem}, _Actor, {?TYPE, {DotStore, _CausalContext}}) ->
             {error, {precondition, {not_present, [Elem]}}};
         false ->
             DeltaDotStore = dot_map:new(dot_set),
-            DeltaCausalContext = dot_set:to_causal_context(CurrentDotSet),
+            DeltaCausalContext = causal_context:to_causal_context(CurrentDotSet),
             Delta = {DeltaDotStore, DeltaCausalContext},
             {ok, {?TYPE, {delta, Delta}}}
     end;

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -169,7 +169,8 @@ query({?TYPE, {DotStore, _CausalContext}}) ->
     sets:from_list(Elements).
 
 %% @doc Merge two `state_awset()'.
-%% Merging will be handled by the causal_join() in the common library.
+%%      Merging is handled by the `merge' function in
+%%      `state_causal_type' common library.
 -spec merge(delta_or_state(), delta_or_state()) -> delta_or_state().
 merge({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     MergeFun = fun({?TYPE, AWSet1}, {?TYPE, AWSet2}) ->
@@ -179,7 +180,7 @@ merge({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:merge(CRDT1, CRDT2, MergeFun).
 
 %% @doc Equality for `state_awset()'.
-%% Since everything is ordered, == should work.
+%%      Since everything is ordered, == should work.
 -spec equal(state_awset(), state_awset()) -> boolean().
 equal({?TYPE, AWSet1}, {?TYPE, AWSet2}) ->
     AWSet1 == AWSet2.
@@ -192,10 +193,10 @@ is_bottom({?TYPE, _}=CRDT) ->
     CRDT == new().
 
 %% @doc Given two `state_awset()', check if the second is and inflation of the first.
-%%      The inflation will be checked by the `is_inflation()` in the common library.
+%% @todo
 -spec is_inflation(state_awset(), state_awset()) -> boolean().
-is_inflation({?TYPE, _}=AWSet1, {?TYPE, _}=AWSet2) ->
-    state_type:is_inflation(AWSet1, AWSet2).
+is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_inflation(CRDT1, CRDT2).
 
 %% @doc Check for strict inflation.
 -spec is_strict_inflation(state_awset(), state_awset()) -> boolean().

--- a/src/state_awset.erl
+++ b/src/state_awset.erl
@@ -270,7 +270,7 @@ query_test() ->
     Set1 = {?TYPE,
         {
             {
-                {dot_map, dot_set}, 
+                {dot_map, dot_set},
                 [{<<"a">>, {dot_set, [{a, 2}]}}]
             },
             [{a, 1}, {a, 2}]
@@ -291,8 +291,8 @@ delta_add_test() ->
 
     ?assertEqual({?TYPE,
         {
-            {   
-                {dot_map, dot_set},  
+            {
+                {dot_map, dot_set},
                 [{<<"a">>, {dot_set, [{Actor, 1}]}}]
             },
             [{Actor, 1}]
@@ -331,7 +331,7 @@ delta_add_test() ->
     ),
     ?assertEqual({?TYPE,
         {
-            {   
+            {
                 {dot_map, dot_set},
                 [{<<"b">>, {dot_set, [{Actor, 3}]}}]
             },
@@ -341,7 +341,7 @@ delta_add_test() ->
     ),
     ?assertEqual({?TYPE,
         {
-            {   
+            {
                 {dot_map, dot_set},
                 [
                     {<<"a">>, {dot_set, [{Actor, 2}]}},
@@ -381,7 +381,7 @@ add_test() ->
     ),
     ?assertEqual({?TYPE,
         {
-            {   
+            {
                 {dot_map, dot_set},
                 [
                     {<<"a">>, {dot_set, [{Actor, 2}]}},

--- a/src/state_awset_ps.erl
+++ b/src/state_awset_ps.erl
@@ -143,7 +143,7 @@ delta_mutate({add, Elem},
                           ordsets:new(),
                           ordsets:add_element(NewEvent, ordsets:new())}}}};
 
-%% Adds a list of elemenets to `state_awset_ps()'.
+%% Adds a list of elements to `state_awset_ps()'.
 delta_mutate({add_all, Elems},
              EventId,
              {?TYPE, {_DataStore, _FilteredOutEvents, AllEvents}}) ->
@@ -180,7 +180,7 @@ delta_mutate({rmv, Elem},
             {error, {precondition, {not_present, Elem}}}
     end;
 
-%% Removes a list of elemenets in `state_awset_ps()'.
+%% Removes a list of elements in `state_awset_ps()'.
 delta_mutate({rmv_all, Elems},
              _EventId,
              {?TYPE, {{ElemDataStore, _EventDataStore},

--- a/src/state_awset_ps.erl
+++ b/src/state_awset_ps.erl
@@ -237,11 +237,11 @@ is_inflation({?TYPE, AWSet1}, {?TYPE, AWSet2}) ->
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
-%% @todo
 %% @doc Join decomposition for `state_awset_ps()'.
+%% @todo
 -spec join_decomposition(state_awset_ps()) -> [state_awset_ps()].
-join_decomposition({?TYPE, AWSet}) ->
-    [AWSet].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
 
 -spec encode(state_type:format(), delta_or_state()) -> binary().
 encode(erlang, {?TYPE, _}=CRDT) ->

--- a/src/state_bcounter.erl
+++ b/src/state_bcounter.erl
@@ -235,9 +235,10 @@ is_strict_inflation({?TYPE, {PNCounter1, GMap1}}, {?TYPE, {PNCounter2, GMap2}}) 
     ?GMAP_TYPE:is_strict_inflation(GMap1, GMap2)).
 
 %% @doc Join decomposition for `state_bcounter()'.
-%% @todo Check how to do this.
+%% @todo
 -spec join_decomposition(state_bcounter()) -> [state_bcounter()].
-join_decomposition({?TYPE, _}) -> [].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
 
 -spec encode(state_type:format(), delta_or_state()) -> binary().
 encode(erlang, {?TYPE, _}=CRDT) ->
@@ -336,7 +337,7 @@ merge_deltas_test() ->
     ?assertEqual({?TYPE, {delta, {{?PNCOUNTER_TYPE, [{1, {4, 0}}, {2, {1, 17}}]}, GMap}}}, DeltaGroup).
 
 join_decomposition_test() ->
-    %% @todo.
+    %% @todo
     ok.
 
 encode_decode_test() ->

--- a/src/state_boolean.erl
+++ b/src/state_boolean.erl
@@ -130,8 +130,8 @@ is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
 
 %% @doc Join decomposition for `state_boolean()'.
 -spec join_decomposition(state_boolean()) -> [state_boolean()].
-join_decomposition({?TYPE, Boolean}) ->
-    [{?TYPE, Boolean}].
+join_decomposition({?TYPE, _}=Boolean) ->
+    [Boolean].
 
 -spec encode(state_type:format(), delta_or_state()) -> binary().
 encode(erlang, {?TYPE, _}=CRDT) ->

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -20,8 +20,6 @@
 %% -------------------------------------------------------------------
 
 %% @doc Common library for causal CRDTs.
-%%      The current implementation does not have any optimisations such as
-%%      the causal context compression.
 %%
 %% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
 %%      Delta State Replicated Data Types (2016)
@@ -30,244 +28,139 @@
 -module(state_causal_type).
 -author("Junghun Yoo <junghun.yoo@cs.ox.ac.uk>").
 
-%% causal_crdt() related.
--export([new_causal_crdt/1,
-         causal_join/2,
-         is_lattice_inflation/2]).
+-export([new/1,
+         merge/2,
+         is_inflation/2]).
 
-%% data_store() related.
--export([new_data_store/1,
-         get_dot_cloud/1,
-         is_bottom_data_store/1]).
-%% dot_cloud() related.
--export([get_next_dot_context/2,
-         insert_dot_context/2,
-         merge_dot_clouds/2]).
-%% {{dot_map, data_store_type()}, dot_map()} related.
--export([get_sub_data_store/2,
-         insert_object/3,
-         remove_object/2,
-         get_all_objects/1,
-         get_objects_count/1]).
+-export_type([causal_crdt/0]).
 
--export_type([dot_context/0,
-              dot_cloud/0,
-              data_store/0,
-              data_store_type/0,
-              causal_crdt/0]).
-
--type dot_actor() :: term().
--type dot_context() :: {dot_actor(), pos_integer()}.
--type dot_cloud() :: ordsets:ordsets(dot_context()).
--type dot_set() :: dot_cloud().
--type dot_fun() :: orddict:orddict(dot_context(), term()).
--type dot_map() :: orddict:orddict(term(), data_store()).
--type data_store_type() :: dot_set | dot_fun | {dot_map, data_store_type()}.
--type data_store() :: {dot_set, dot_set()}
-                    | {dot_fun, dot_fun()}
-                    | {{dot_map, data_store_type()}, dot_map()}.
--type causal_crdt() :: {data_store(), dot_cloud()}.
+-type causal_crdt() :: {
+                            dot_store:dot_store(), 
+                            causal_context:causal_context()
+                       }.
 
 %% @doc Create an empty CausalCRDT.
--spec new_causal_crdt(data_store_type()) -> causal_crdt().
-new_causal_crdt(DataStoreType) ->
-    {new_data_store(DataStoreType), ordsets:new()}.
+-spec new(dot_store:type()) -> causal_crdt().
+new(CType) ->
+    {DotStoreType, Args} = state_type:extract_args(CType),
+    {DotStoreType:new(Args), causal_context:new()}.
 
-%% @doc Universal causal join for a two CausalCRDTs.
--spec causal_join(causal_crdt(), causal_crdt()) -> causal_crdt().
-causal_join({DataStore, DotCloud}, {DataStore, DotCloud}) ->
-    {DataStore, DotCloud};
-causal_join({{dot_set, DataStoreA}, DotCloudA},
-            {{dot_set, DataStoreB}, DotCloudB}) ->
-    {{dot_set, ordsets:union([ordsets:intersection(DataStoreA, DataStoreB)] ++
-                             [ordsets:subtract(DataStoreA, DotCloudB)] ++
-                             [ordsets:subtract(DataStoreB, DotCloudA)])},
-     merge_dot_clouds(DotCloudA, DotCloudB)};
-causal_join({{dot_fun, DataStoreA}=_Fst, DotCloudA},
-            {{dot_fun, DataStoreB}=Snd, DotCloudB}) ->
-    DomainSnd = get_dot_cloud(Snd),
-    InterDataStore =
-        orddict:fold(fun(DotContext, Object, {dot_fun, DataStore}) ->
-                             case lists:member(DotContext, DomainSnd) of
-                                 true ->
-                                     {dot_fun, orddict:store(DotContext,
-                                                             Object,
-                                                             DataStore)};
-                                 false ->
-                                     {dot_fun, DataStore}
-                             end
-                     end, new_data_store(dot_fun), DataStoreA),
-    MergedDataStore0 =
-        orddict:fold(fun(DotContext, Object, {dot_fun, DataStore}) ->
-                             case ordsets:is_element(DotContext, DotCloudB) of
-                                 true ->
-                                     {dot_fun, DataStore};
-                                 false ->
-                                     {dot_fun, orddict:store(DotContext,
-                                                             Object,
-                                                             DataStore)}
-                             end
-                     end, InterDataStore, DataStoreA),
-    MergedDataStore1 =
-        orddict:fold(fun(DotContext, Object, {dot_fun, DataStore}) ->
-                             case ordsets:is_element(DotContext, DotCloudA) of
-                                 true ->
-                                     {dot_fun, DataStore};
-                                 false ->
-                                     {dot_fun, orddict:store(DotContext,
-                                                             Object,
-                                                             DataStore)}
-                             end
-                     end, MergedDataStore0, DataStoreB),
-    {MergedDataStore1, merge_dot_clouds(DotCloudA, DotCloudB)};
-causal_join({{{dot_map, ValueDataStoreType}, DataStoreA}=Fst, DotCloudA},
-            {{{dot_map, ValueDataStoreType}, DataStoreB}=Snd, DotCloudB}) ->
-    UnionObjects = ordsets:union(ordsets:from_list(orddict:fetch_keys(DataStoreA)),
-                                 ordsets:from_list(orddict:fetch_keys(DataStoreB))),
-    MergedDataStore =
-        ordsets:fold(fun(Object, MergedDataStore0) ->
-                             {ok, SubDataStoreA} = get_sub_data_store(Object, Fst),
-                             {ok, SubDataStoreB} = get_sub_data_store(Object, Snd),
-                             {MergedSubDataStore, _} =
-                                 causal_join({SubDataStoreA, DotCloudA},
-                                             {SubDataStoreB, DotCloudB}),
-                             case is_bottom_data_store(MergedSubDataStore) of
-                                 true ->
-                                     MergedDataStore0;
-                                 false ->
-                                     insert_object(Object,
-                                                   MergedSubDataStore,
-                                                   MergedDataStore0)
-                             end
-                     end, new_data_store({dot_map, ValueDataStoreType}), UnionObjects),
-    {MergedDataStore, merge_dot_clouds(DotCloudA, DotCloudB)}.
+%% @doc Universal merge for a two CausalCRDTs.
+-spec merge(causal_crdt(), causal_crdt()) -> causal_crdt().
+merge({DotStore, CausalContext}, {DotStore, CausalContext}) ->
+    {DotStore, CausalContext};
 
-%% @doc Determine if a change for a given causal crdt is an inflation or not.
-%%
-%% Given a particular causal crdt and two instances of that causal crdt,
-%% determine if `B(second)' is an inflation of `A(first)'.
--spec is_lattice_inflation(causal_crdt(), causal_crdt()) -> boolean().
-is_lattice_inflation({DataStoreA, DotCloudA}, {DataStoreB, DotCloudB}) ->
-    DotCloudAList = get_maxs_for_all(DotCloudA),
-    DotCloudBList = get_maxs_for_all(DotCloudB),
-    is_inflation(DotCloudAList, DotCloudBList) andalso
-        ordsets:is_subset(get_dot_cloud(DataStoreB), get_dot_cloud(DataStoreA)).
+merge({{dot_set, _}=DotSetA, CausalContextA},
+      {{dot_set, _}=DotSetB, CausalContextB}) ->
 
-%% @doc Create an empty DataStore.
-new_data_store(dot_set) ->
-    {dot_set, ordsets:new()};
-new_data_store(dot_fun) ->
-    {dot_fun, orddict:new()};
-new_data_store({dot_map, ValueDataStoreType}) ->
-    {{dot_map, ValueDataStoreType}, orddict:new()}.
+    DotSetL = dot_set:intersection(DotSetA, DotSetB),
+    DotSetM = dot_set:subtract(
+        DotSetA,
+        causal_context:to_dot_set(CausalContextB)
+    ),
+    DotSetR = dot_set:subtract(
+        DotSetB,
+        causal_context:to_dot_set(CausalContextA)
+    ),
 
-%% @doc Get DotCloud from DataStore.
--spec get_dot_cloud(data_store()) -> dot_cloud().
-get_dot_cloud({dot_set, DataStore}) ->
-    DataStore;
-get_dot_cloud({dot_fun, DataStore}) ->
-    ordsets:from_list(orddict:fetch_keys(DataStore));
-get_dot_cloud({{dot_map, _ValueDataStoreType}, DataStore}) ->
-    orddict:fold(fun(_Object, SubDataStore, DotCloud) ->
-                         ordsets:union(DotCloud, get_dot_cloud(SubDataStore))
-                 end, ordsets:new(), DataStore).
+    DotStore = dot_set:union(
+        dot_set:union(DotSetL, DotSetM),
+        DotSetR
+    ),
+    CausalContext = causal_context:merge(CausalContextA, CausalContextB),
 
-%% @doc Check whether the DataStore is empty.
--spec is_bottom_data_store(data_store()) -> boolean().
-is_bottom_data_store({dot_set, DataStore}) ->
-    ordsets:size(DataStore) == 0;
-is_bottom_data_store({dot_fun, DataStore}) ->
-    orddict:is_empty(DataStore);
-is_bottom_data_store({{dot_map, _ValueDataStoreType}, DataStore}) ->
-    orddict:is_empty(DataStore).
+    {DotStore, CausalContext};
 
-%% @doc Get the Actor's next DotContext from DotCloud.
--spec get_next_dot_context(dot_actor(), dot_cloud()) -> dot_context().
-get_next_dot_context(DotActor, DotCloud) ->
-    MaxCounter = ordsets:fold(fun({DotActor0, DotCounter0}, MaxValue0) ->
-                                      case (DotActor0 == DotActor) andalso
-                                              (DotCounter0 > MaxValue0) of
-                                          true ->
-                                              DotCounter0;
-                                          false ->
-                                              MaxValue0
-                                      end
-                              end, 0, DotCloud),
-    {DotActor, MaxCounter + 1}.
+merge({{{dot_fun, CRDTType}, _}=DotFunA, CausalContextA},
+      {{{dot_fun, CRDTType}, _}=DotFunB, CausalContextB}) ->
 
-%% @doc Insert a dot to DotCloud.
--spec insert_dot_context(dot_context(), dot_cloud()) -> dot_cloud().
-insert_dot_context(DotContext, DotCloud) ->
-    ordsets:add_element(DotContext, DotCloud).
+    DotSetA = causal_context:to_dot_set(
+        dot_fun:to_causal_context(DotFunA)
+    ),
+    DotSetB = causal_context:to_dot_set(
+        dot_fun:to_causal_context(DotFunB)
+    ),
+    CCDotSetA = causal_context:to_dot_set(CausalContextA),
+    CCDotSetB = causal_context:to_dot_set(CausalContextB),
 
-%% @doc Merge two DotClouds.
--spec merge_dot_clouds(dot_cloud(), dot_cloud()) -> dot_cloud().
-merge_dot_clouds(DotCloudA, DotCloudB) ->
-    ordsets:union(DotCloudA, DotCloudB).
+    CommonDotSet = dot_set:intersection(DotSetA, DotSetB),
 
-%% @doc Get SubDataStore pointed by the object from {dot_map, dot_map()}.
--spec get_sub_data_store(term(), {{dot_map, data_store_type()}, dot_map()}) ->
-          {ok, data_store()}.
-get_sub_data_store(Object, {{dot_map, ValueDataStoreType}, DataStore}) ->
-    case orddict:find(Object, DataStore) of
-        {ok, SubDataStore} ->
-            {ok, SubDataStore};
-        error ->
-            {ok, new_data_store(ValueDataStoreType)}
-    end.
+    DotFun0 = lists:foldl(
+        fun(Dot, DotFun) ->
+            ValueA = dot_fun:fetch(Dot, DotFunA),
+            ValueB = dot_fun:fetch(Dot, DotFunB),
+            Value = CRDTType:merge(ValueA, ValueB),
+            dot_fun:store(Dot, Value, DotFun)
+        end,
+        dot_fun:new([CRDTType]),
+        dot_set:to_list(CommonDotSet)
+    ),
 
-%% @doc Insert (key: Object, value: SubDataStore) into {dot_map, dot_map()}.
--spec insert_object(term(), data_store(), {{dot_map, data_store_type()}, dot_map()}) ->
-          {{dot_map, data_store_type()}, dot_map()}.
-insert_object(Object, SubDataStore, {{dot_map, ValueDataStoreType}, DataStore}) ->
-    {{dot_map, ValueDataStoreType}, orddict:store(Object, SubDataStore, DataStore)}.
-
-%% @doc Remove the Object from DataStore.
-%% The Object has to be in the DataStore. This can be checked by
-%% get_data_store().
--spec remove_object(term(), {{dot_map, data_store_type()}, dot_map()}) ->
-          {{dot_map, data_store_type()}, dot_map()}.
-remove_object(Object, {{dot_map, ValueDataStoreType}, DataStore}) ->
-    {{dot_map, ValueDataStoreType}, orddict:erase(Object, DataStore)}.
-
-%% @doc Get all Objects from DataStore.
--spec get_all_objects({{dot_map, data_store_type()}, dot_map()}) -> [term()].
-get_all_objects({{dot_map, _ValueDataStoreType}, DataStore}) ->
-    orddict:fetch_keys(DataStore).
-
-%% @doc Get the number of Objects from DataStore.
--spec get_objects_count({{dot_map, data_store_type()}, dot_map()}) -> non_neg_integer().
-get_objects_count({{dot_map, _ValueDataStoreType}, DataStore}) ->
-    orddict:size(DataStore).
-
-%% @private
-%% @todo This function can be used for the compressing functionality.
-get_maxs_for_all(DotCloud) ->
-    ordsets:fold(fun({DotActor0, DotCounter0}, MaxList) ->
-                         {Counter, NewList} =
-                             case lists:keytake(DotActor0, 1, MaxList) of
-                                 false ->
-                                     {DotCounter0, MaxList};
-                                 {value, {_DotActor, C}, ModList} ->
-                                     {max(DotCounter0, C), ModList}
-                             end,
-                         [{DotActor0, Counter}|NewList]
-                 end, [], DotCloud).
-
-%% @private
-is_inflation([], _) ->
-    % all DotClouds are the inflation of the empty DotCloud
-    true;
-is_inflation(DotCloudA, DotCloudB) ->
-    [{DotActorA, DotCounterA} | RestA] = DotCloudA,
-    case lists:keyfind(DotActorA, 1, DotCloudB) of
-        false ->
-            false;
-        {_, DotCounterB} ->
-            case DotCounterA == DotCounterB of
+    DotFun1 = lists:foldl(
+        fun(Dot, DotFun) ->
+            case dot_set:is_element(Dot, CCDotSetB) of
                 true ->
-                    is_inflation(RestA, DotCloudB);
+                    DotFun;
                 false ->
-                    DotCounterA < DotCounterB
+                    Value = dot_fun:fetch(Dot, DotFunA),
+                    dot_fun:store(Dot, Value, DotFun)
             end
-    end.
+        end,
+        dot_fun:fetch_keys(DotFunA),
+        DotFun0
+    ),
+
+    DotFun2 = lists:foldl(
+        fun(Dot, DotFun) ->
+            case dot_set:is_element(Dot, CCDotSetA) of
+                true ->
+                    DotFun;
+                false ->
+                    Value = dot_fun:fetch(Dot, DotFunB),
+                    dot_fun:store(Dot, Value, DotFun)
+            end 
+        end,
+        dot_fun:fetch_keys(DotFunB),
+        DotFun1
+    ),
+
+    DotStore = DotFun2,
+    CausalContext = causal_context:merge(CausalContextA, CausalContextB),
+    {DotStore, CausalContext};
+
+merge({{{dot_map, DotStoreType}, _}=DotMapA, CausalContextA},
+      {{{dot_map, DotStoreType}, _}=DotMapB, CausalContextB}) ->
+
+    KeysA = dot_map:fetch_keys(DotMapA),
+    KeysB = dot_map:fetch_keys(DotMapB),
+    Keys = ordsets:union(
+        ordsets:from_list(KeysA),
+        ordsets:from_list(KeysB)
+    ),
+
+    DotStore = ordsets:fold(
+        fun(Key, DotMap) ->
+            KeyDotStoreA = dot_map:fetch(Key, DotMapA),
+            KeyDotStoreB = dot_map:fetch(Key, DotMapB),
+
+            {VK, _} = merge(
+                {KeyDotStoreA, CausalContextA},
+                {KeyDotStoreB, CausalContextB}
+            ),
+
+            case DotStoreType:is_empty(VK) of
+                true ->
+                    DotMap;
+                false ->
+                    dot_map:store(Key, VK, DotMap)
+            end
+        end,
+        dot_map:new(dot_set),
+        Keys
+    ),
+    CausalContext = causal_context:merge(CausalContextA, CausalContextB),
+
+    {DotStore, CausalContext}.
+
+-spec is_inflation(causal_crdt(), causal_crdt()) -> boolean().
+is_inflation(_, _) -> true.

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -26,6 +26,10 @@
 -module(state_causal_type).
 -author("Junghun Yoo <junghun.yoo@cs.ox.ac.uk>").
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([new/1,
          merge/2]).
 

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -27,8 +27,7 @@
 -author("Junghun Yoo <junghun.yoo@cs.ox.ac.uk>").
 
 -export([new/1,
-         merge/2,
-         is_inflation/2]).
+         merge/2]).
 
 -export_type([causal_crdt/0]).
 
@@ -159,6 +158,3 @@ merge({{{dot_map, DotStoreType}, _}=DotMapA, CausalContextA},
     CausalContext = causal_context:merge(CausalContextA, CausalContextB),
 
     {DotStore, CausalContext}.
-
--spec is_inflation(causal_crdt(), causal_crdt()) -> boolean().
-is_inflation(_, _) -> true.

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -103,8 +103,8 @@ merge({{{dot_fun, CRDTType}, _}=DotFunA, CausalContextA},
                     dot_fun:store(Dot, Value, DotFun)
             end
         end,
-        dot_fun:fetch_keys(DotFunA),
-        DotFun0
+        DotFun0,
+        dot_fun:fetch_keys(DotFunA)
     ),
 
     DotFun2 = lists:foldl(
@@ -117,8 +117,8 @@ merge({{{dot_fun, CRDTType}, _}=DotFunA, CausalContextA},
                     dot_fun:store(Dot, Value, DotFun)
             end 
         end,
-        dot_fun:fetch_keys(DotFunB),
-        DotFun1
+        DotFun1,
+        dot_fun:fetch_keys(DotFunB)
     ),
 
     DotStore = DotFun2,

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -144,19 +144,21 @@ merge({{{dot_map, DotStoreType}, _}=DotMapA, CausalContextA},
             KeyDotStoreA = dot_map:fetch(Key, DotMapA),
             KeyDotStoreB = dot_map:fetch(Key, DotMapB),
 
-            {VK, _} = merge(
+            {{CType, _}=VK, _} = merge(
                 {KeyDotStoreA, CausalContextA},
                 {KeyDotStoreB, CausalContextB}
             ),
 
-            case DotStoreType:is_empty(VK) of
+            {SubDotStoreType, _} = state_type:extract_args(CType),
+
+            case SubDotStoreType:is_empty(VK) of
                 true ->
                     DotMap;
                 false ->
                     dot_map:store(Key, VK, DotMap)
             end
         end,
-        dot_map:new(dot_set),
+        dot_map:new(DotStoreType),
         Keys
     ),
     CausalContext = causal_context:merge(CausalContextA, CausalContextB),

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -32,7 +32,7 @@
 -export_type([causal_crdt/0]).
 
 -type causal_crdt() :: {
-                            dot_store:dot_store(), 
+                            dot_store:dot_store(),
                             causal_context:causal_context()
                        }.
 
@@ -115,7 +115,7 @@ merge({{{dot_fun, CRDTType}, _}=DotFunA, CausalContextA},
                 false ->
                     Value = dot_fun:fetch(Dot, DotFunB),
                     dot_fun:store(Dot, Value, DotFun)
-            end 
+            end
         end,
         DotFun1,
         dot_fun:fetch_keys(DotFunB)

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -89,7 +89,7 @@ merge({{{dot_fun, CRDTType}, _}=DotFunA, CausalContextA},
             Value = CRDTType:merge(ValueA, ValueB),
             dot_fun:store(Dot, Value, DotFun)
         end,
-        dot_fun:new([CRDTType]),
+        dot_fun:new(CRDTType),
         dot_set:to_list(CommonDotSet)
     ),
 

--- a/src/state_causal_type.erl
+++ b/src/state_causal_type.erl
@@ -76,10 +76,10 @@ merge({{{dot_fun, CRDTType}, _}=DotFunA, CausalContextA},
       {{{dot_fun, CRDTType}, _}=DotFunB, CausalContextB}) ->
 
     DotSetA = causal_context:to_dot_set(
-        dot_fun:to_causal_context(DotFunA)
+        causal_context:to_causal_context(DotFunA)
     ),
     DotSetB = causal_context:to_dot_set(
-        dot_fun:to_causal_context(DotFunB)
+        causal_context:to_causal_context(DotFunB)
     ),
     CCDotSetA = causal_context:to_dot_set(CausalContextA),
     CCDotSetB = causal_context:to_dot_set(CausalContextB),

--- a/src/state_dwflag.erl
+++ b/src/state_dwflag.erl
@@ -20,6 +20,13 @@
 %% @doc Disable-Wins Flag CRDT.
 %%      Starts enabled.
 %%
+%%      Follows the same strategy used in Enable-Wins Flag but,
+%%      instead of creating a new dot when enabling the flag,
+%%      we create a new dot when disabling it.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
 
 -module(state_dwflag).
 -author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -75,7 +75,7 @@ is_delta({?TYPE, _}=CRDT) ->
 
 %% @doc Mutate a `state_ewflag()'.
 -spec mutate(state_ewflag_op(), type:id(), state_ewflag()) ->
-    {ok, state_ewflag()} | {error, {precondition, {not_present, [element()]}}}.
+    {ok, state_ewflag()}.
 mutate(Op, Actor, {?TYPE, _Flag}=CRDT) ->
     state_type:mutate(Op, Actor, CRDT).
 

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -138,12 +138,16 @@ is_bottom({?TYPE, _}=CRDT) ->
 
 %% @doc Given two `state_ewflag()', check if the second is and inflation of the first.
 %% @todo
--spec is_inflation(state_ewflag(), state_ewflag()) -> boolean().
+-spec is_inflation(delta_or_state(), state_ewflag()) -> boolean().
+is_inflation({?TYPE, {delta, Flag1}}, {?TYPE, Flag2}) ->
+    is_inflation({?TYPE, Flag1}, {?TYPE, Flag2});
 is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_inflation(CRDT1, CRDT2).
 
 %% @doc Check for strict inflation.
--spec is_strict_inflation(state_ewflag(), state_ewflag()) -> boolean().
+-spec is_strict_inflation(delta_or_state(), state_ewflag()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Flag1}}, {?TYPE, Flag2}) ->
+    is_strict_inflation({?TYPE, Flag1}, {?TYPE, Flag2});
 is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -50,7 +50,6 @@
 -type state_ewflag_op() :: enable | disable.
 
 %% @doc Create a new, empty `state_ewflag()'
-%%      DotMap<Elem, DotFlag>
 -spec new() -> state_ewflag().
 new() ->
     {?TYPE, state_causal_type:new(dot_set)}.

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -90,8 +90,8 @@ mutate(Op, Actor, {?TYPE, _Flag}=CRDT) ->
 delta_mutate(enable, Actor, {?TYPE, {DotStore, CausalContext}}) ->
     NextDot = causal_context:next_dot(Actor, CausalContext),
 
-    EmptyDotFlag = dot_set:new(),
-    DeltaDotStore = dot_set:add_element(NextDot, EmptyDotFlag),
+    EmptyDotSet = dot_set:new(),
+    DeltaDotStore = dot_set:add_element(NextDot, EmptyDotSet),
     DeltaCausalContext = dot_set:to_causal_context(
         dot_set:union(DotStore, DeltaDotStore)
     ),

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -92,7 +92,7 @@ delta_mutate(enable, Actor, {?TYPE, {DotStore, CausalContext}}) ->
 
     EmptyDotSet = dot_set:new(),
     DeltaDotStore = dot_set:add_element(NextDot, EmptyDotSet),
-    DeltaCausalContext = dot_set:to_causal_context(
+    DeltaCausalContext = causal_context:to_causal_context(
         dot_set:union(DotStore, DeltaDotStore)
     ),
 
@@ -102,7 +102,7 @@ delta_mutate(enable, Actor, {?TYPE, {DotStore, CausalContext}}) ->
 %% @doc Disables `state_ewflag()'.
 delta_mutate(disable, _Actor, {?TYPE, {DotStore, _CausalContext}}) ->
     DeltaDotStore = dot_set:new(),
-    DeltaCausalContext = dot_set:to_causal_context(DotStore),
+    DeltaCausalContext = causal_context:to_causal_context(DotStore),
 
     Delta = {DeltaDotStore, DeltaCausalContext},
     {ok, {?TYPE, {delta, Delta}}}.

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -47,7 +47,6 @@
 -opaque delta_state_ewflag() :: {?TYPE, {delta, payload()}}.
 -type delta_or_state() :: state_ewflag() | delta_state_ewflag().
 -type payload() :: state_causal_type:causal_crdt().
--type element() :: term().
 -type state_ewflag_op() :: enable | disable.
 
 %% @doc Create a new, empty `state_ewflag()'

--- a/src/state_ewflag.erl
+++ b/src/state_ewflag.erl
@@ -1,0 +1,398 @@
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Enable-Wins Flag CRDT.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(state_ewflag).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-behaviour(type).
+-behaviour(state_type).
+
+-define(TYPE, ?MODULE).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([new/0, new/1, new_delta/0, new_delta/1, is_delta/1]).
+-export([mutate/3, delta_mutate/3, merge/2]).
+-export([query/1, equal/2, is_bottom/1, is_inflation/2, is_strict_inflation/2]).
+-export([join_decomposition/1]).
+-export([encode/2, decode/2]).
+
+-export_type([state_ewflag/0, delta_state_ewflag/0, state_ewflag_op/0]).
+
+-opaque state_ewflag() :: {?TYPE, payload()}.
+-opaque delta_state_ewflag() :: {?TYPE, {delta, payload()}}.
+-type delta_or_state() :: state_ewflag() | delta_state_ewflag().
+-type payload() :: state_causal_type:causal_crdt().
+-type element() :: term().
+-type state_ewflag_op() :: enable | disable.
+
+%% @doc Create a new, empty `state_ewflag()'
+%%      DotMap<Elem, DotFlag>
+-spec new() -> state_ewflag().
+new() ->
+    {?TYPE, state_causal_type:new(dot_set)}.
+
+%% @doc Create a new, empty `state_ewflag()'
+-spec new([term()]) -> state_ewflag().
+new([]) ->
+    new().
+
+-spec new_delta() -> delta_state_ewflag().
+new_delta() ->
+    state_type:new_delta(?TYPE).
+
+-spec new_delta([term()]) -> delta_state_ewflag().
+new_delta([]) ->
+    new_delta().
+
+-spec is_delta(delta_or_state()) -> boolean().
+is_delta({?TYPE, _}=CRDT) ->
+    state_type:is_delta(CRDT).
+
+%% @doc Mutate a `state_ewflag()'.
+-spec mutate(state_ewflag_op(), type:id(), state_ewflag()) ->
+    {ok, state_ewflag()} | {error, {precondition, {not_present, [element()]}}}.
+mutate(Op, Actor, {?TYPE, _Flag}=CRDT) ->
+    state_type:mutate(Op, Actor, CRDT).
+
+%% @doc Delta-mutate a `state_ewflag()'.
+%%      The first argument can be:
+%%          - `enable'
+%%          - `disable'
+%%      The second argument is the replica id.
+%%      The third argument is the `state_ewflag()' to be inflated.
+-spec delta_mutate(state_ewflag_op(), type:id(), state_ewflag()) ->
+    {ok, delta_state_ewflag()}.
+
+%% @doc Enables `state_ewflag()'.
+delta_mutate(enable, Actor, {?TYPE, {DotStore, CausalContext}}) ->
+    NextDot = causal_context:next_dot(Actor, CausalContext),
+
+    EmptyDotFlag = dot_set:new(),
+    DeltaDotStore = dot_set:add_element(NextDot, EmptyDotFlag),
+    DeltaCausalContext = dot_set:to_causal_context(
+        dot_set:union(DotStore, DeltaDotStore)
+    ),
+
+    Delta = {DeltaDotStore, DeltaCausalContext},
+    {ok, {?TYPE, {delta, Delta}}};
+
+%% @doc Disables `state_ewflag()'.
+delta_mutate(disable, _Actor, {?TYPE, {DotStore, _CausalContext}}) ->
+    DeltaDotStore = dot_set:new(),
+    DeltaCausalContext = dot_set:to_causal_context(DotStore),
+
+    Delta = {DeltaDotStore, DeltaCausalContext},
+    {ok, {?TYPE, {delta, Delta}}}.
+
+%% @doc Returns the value of the `state_ewflag()'.
+-spec query(state_ewflag()) -> boolean().
+query({?TYPE, {DotStore, _CausalContext}}) ->
+    not dot_set:is_empty(DotStore).
+
+%% @doc Merge two `state_ewflag()'.
+%%      Merging is handled by the `merge' function in
+%%      `state_causal_type' common library.
+-spec merge(delta_or_state(), delta_or_state()) -> delta_or_state().
+merge({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    MergeFun = fun({?TYPE, Flag1}, {?TYPE, Flag2}) ->
+        Flag = state_causal_type:merge(Flag1, Flag2),
+        {?TYPE, Flag}
+    end,
+    state_type:merge(CRDT1, CRDT2, MergeFun).
+
+%% @doc Equality for `state_ewflag()'.
+%%      Since everything is ordered, == should work.
+-spec equal(state_ewflag(), state_ewflag()) -> boolean().
+equal({?TYPE, Flag1}, {?TYPE, Flag2}) ->
+    Flag1 == Flag2.
+
+%% @doc Check if an `state_ewflag()' is bottom.
+-spec is_bottom(delta_or_state()) -> boolean().
+is_bottom({?TYPE, {delta, Flag}}) ->
+    is_bottom({?TYPE, Flag});
+is_bottom({?TYPE, _}=CRDT) ->
+    CRDT == new().
+
+%% @doc Given two `state_ewflag()', check if the second is and inflation of the first.
+%% @todo
+-spec is_inflation(state_ewflag(), state_ewflag()) -> boolean().
+is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_inflation(CRDT1, CRDT2).
+
+%% @doc Check for strict inflation.
+-spec is_strict_inflation(state_ewflag(), state_ewflag()) -> boolean().
+is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_strict_inflation(CRDT1, CRDT2).
+
+%% @doc Join decomposition for `state_ewflag()'.
+%% @todo
+-spec join_decomposition(state_ewflag()) -> [state_ewflag()].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
+
+-spec encode(state_type:format(), delta_or_state()) -> binary().
+encode(erlang, {?TYPE, _}=CRDT) ->
+    erlang:term_to_binary(CRDT).
+
+-spec decode(state_type:format(), binary()) -> delta_or_state().
+decode(erlang, Binary) ->
+    {?TYPE, _} = CRDT = erlang:binary_to_term(Binary),
+    CRDT.
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+new_test() ->
+    ?assertEqual({?TYPE, {{dot_set, ordsets:new()}, ordsets:new()}},
+                 new()),
+    ?assertEqual({?TYPE, {delta, {{dot_set, ordsets:new()}, ordsets:new()}}},
+                 new_delta()).
+
+query_test() ->
+    Flag0 = new(),
+    Flag1 = {?TYPE,
+        {
+            {dot_set, [{a, 2}]},
+            [{a, 1}, {a, 2}]
+        }
+    },
+    ?assertEqual(false, query(Flag0)),
+    ?assertEqual(true, query(Flag1)).
+
+delta_mutate_test() ->
+    ActorOne = 1,
+    ActorTwo = 2,
+    Flag0 = new(),
+    {ok, {?TYPE, {delta, Delta1}}} = delta_mutate(enable, ActorOne, Flag0),
+    Flag1 = merge({?TYPE, Delta1}, Flag0),
+    {ok, {?TYPE, {delta, Delta2}}} = delta_mutate(enable, ActorTwo, Flag1),
+    Flag2 = merge({?TYPE, Delta2}, Flag1),
+    {ok, {?TYPE, {delta, Delta3}}} = delta_mutate(disable, ActorTwo, Flag2),
+    Flag3 = merge({?TYPE, Delta3}, Flag2),
+    {ok, {?TYPE, {delta, Delta4}}} = delta_mutate(enable, ActorTwo, Flag3),
+    Flag4 = merge({?TYPE, Delta4}, Flag3),
+
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorOne, 1}]},
+            [{ActorOne, 1}]
+        }},
+        {?TYPE, Delta1}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorOne, 1}]},
+            [{ActorOne, 1}]
+        }},
+        Flag1
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorTwo, 1}]},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        {?TYPE, Delta2}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorTwo, 1}]},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        Flag2
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, []},
+            [{ActorTwo, 1}]
+        }},
+        {?TYPE, Delta3}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, []},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        Flag3
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorTwo, 2}]},
+            [{ActorTwo, 2}]
+        }},
+        {?TYPE, Delta4}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorTwo, 2}]},
+            [{ActorOne, 1}, {ActorTwo, 1}, {ActorTwo, 2}]
+        }},
+        Flag4
+    ).
+
+mutate_test() ->
+    ActorOne = 1,
+    ActorTwo = 2,
+    Flag0 = new(),
+    {ok, Flag1} = mutate(enable, ActorOne, Flag0),
+    {ok, Flag2} = mutate(enable, ActorTwo, Flag1),
+    {ok, Flag3} = mutate(disable, ActorTwo, Flag2),
+    {ok, Flag4} = mutate(enable, ActorTwo, Flag3),
+
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorOne, 1}]},
+            [{ActorOne, 1}]
+        }},
+        Flag1
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorTwo, 1}]},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        Flag2
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, []},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        Flag3
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {dot_set, [{ActorTwo, 2}]},
+            [{ActorOne, 1}, {ActorTwo, 1}, {ActorTwo, 2}]
+        }},
+        Flag4
+    ).
+
+merge_idempontent_test() ->
+    Flag1 = {?TYPE, {{dot_set, []}, [{1, 1}]}},
+    Flag2 = {?TYPE, {{dot_set, [{2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag3 = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag4 = merge(Flag1, Flag1),
+    Flag5 = merge(Flag2, Flag2),
+    Flag6 = merge(Flag3, Flag3),
+    ?assertEqual(Flag1, Flag4),
+    ?assertEqual(Flag2, Flag5),
+    ?assertEqual(Flag3, Flag6).
+
+merge_commutative_test() ->
+    Flag1 = {?TYPE, {{dot_set, []}, [{1, 1}]}},
+    Flag2 = {?TYPE, {{dot_set, [{2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag3 = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag4 = merge(Flag1, Flag2),
+    Flag5 = merge(Flag2, Flag1),
+    Flag6 = merge(Flag1, Flag3),
+    Flag7 = merge(Flag3, Flag1),
+    Flag8 = merge(Flag2, Flag3),
+    Flag9 = merge(Flag3, Flag2),
+    Flag10 = merge(Flag1, merge(Flag2, Flag3)),
+    Flag1_2 = Flag2,
+    Flag1_3 = Flag2,
+    Flag2_3 = Flag2,
+    ?assertEqual(Flag1_2, Flag4),
+    ?assertEqual(Flag1_2, Flag5),
+    ?assertEqual(Flag1_3, Flag6),
+    ?assertEqual(Flag1_3, Flag7),
+    ?assertEqual(Flag2_3, Flag8),
+    ?assertEqual(Flag2_3, Flag9),
+    ?assertEqual(Flag1_3, Flag10).
+
+merge_delta_test() ->
+    Flag1 = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Delta1 = {?TYPE, {delta, {{dot_set, []}, [{1, 1}]}}},
+    Delta2 = {?TYPE, {delta, {{dot_set, []}, [{2, 3}]}}},
+    Flag2 = merge(Delta1, Flag1),
+    Flag3 = merge(Flag1, Delta2),
+    DeltaGroup = merge(Delta1, Delta2),
+    ?assertEqual({?TYPE, {{dot_set, [{2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}}, Flag2),
+    ?assertEqual({?TYPE, {{dot_set, [{1, 1}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}}, Flag3),
+    ?assertEqual({?TYPE, {delta, {{dot_set, []}, [{1, 1}, {2, 3}]}}}, DeltaGroup).
+
+equal_test() ->
+    Flag1 = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag2 = {?TYPE, {{dot_set, [{1, 1}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag3 = {?TYPE, {{dot_set, [{1, 1}]}, [{1, 1}, {2, 1}, {2, 2}]}},
+    ?assert(equal(Flag1, Flag1)),
+    ?assert(equal(Flag2, Flag2)),
+    ?assert(equal(Flag3, Flag3)),
+    ?assertNot(equal(Flag1, Flag2)),
+    ?assertNot(equal(Flag1, Flag3)),
+    ?assertNot(equal(Flag2, Flag3)).
+
+is_bottom_test() ->
+    Flag0 = new(),
+    Flag1 = {?TYPE, {{dot_set, []}, [{2, 3}]}},
+    ?assert(is_bottom(Flag0)),
+    ?assertNot(is_bottom(Flag1)).
+
+is_inflation_test() ->
+    Flag1 = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag2 = {?TYPE, {{dot_set, [{2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag3 = {?TYPE, {{dot_set, [{1, 1}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    ?assert(is_inflation(Flag1, Flag1)),
+    ?assert(is_inflation(Flag1, Flag2)),
+    ?assertNot(is_inflation(Flag2, Flag1)),
+    ?assert(is_inflation(Flag1, Flag3)),
+    ?assertNot(is_inflation(Flag2, Flag3)),
+    ?assertNot(is_inflation(Flag3, Flag2)),
+    %% check inflation with merge
+    ?assert(state_type:is_inflation(Flag1, Flag1)),
+    ?assert(state_type:is_inflation(Flag1, Flag2)),
+    ?assertNot(state_type:is_inflation(Flag2, Flag1)),
+    ?assert(state_type:is_inflation(Flag1, Flag3)),
+    ?assertNot(state_type:is_inflation(Flag2, Flag3)),
+    ?assertNot(state_type:is_inflation(Flag3, Flag2)).
+
+is_strict_inflation_test() ->
+    Flag1 = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag2 = {?TYPE, {{dot_set, [{2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Flag3 = {?TYPE, {{dot_set, [{1, 1}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    ?assertNot(is_strict_inflation(Flag1, Flag1)),
+    ?assert(is_strict_inflation(Flag1, Flag2)),
+    ?assertNot(is_strict_inflation(Flag2, Flag1)),
+    ?assert(is_strict_inflation(Flag1, Flag3)),
+    ?assertNot(is_strict_inflation(Flag2, Flag3)),
+    ?assertNot(is_strict_inflation(Flag3, Flag2)).
+
+join_decomposition_test() ->
+    %% @todo
+    ok.
+
+encode_decode_test() ->
+    Flag = {?TYPE, {{dot_set, [{1, 1}, {2, 3}]}, [{1, 1}, {2, 1}, {2, 2}, {2, 3}]}},
+    Binary = encode(erlang, Flag),
+    EFlag = decode(erlang, Binary),
+    ?assertEqual(Flag, EFlag).
+
+-endif.

--- a/src/state_gcounter.erl
+++ b/src/state_gcounter.erl
@@ -261,8 +261,8 @@ merge_idempotent_test() ->
     Counter2 = {?TYPE, [{<<"6">>, 6}, {<<"7">>, 7}]},
     Counter3 = merge(Counter1, Counter1),
     Counter4 = merge(Counter2, Counter2),
-    ?assertEqual({?TYPE, [{<<"5">>, 5}]}, Counter3),
-    ?assertEqual({?TYPE, [{<<"6">>, 6}, {<<"7">>, 7}]}, Counter4).
+    ?assertEqual(Counter1, Counter3),
+    ?assertEqual(Counter2, Counter4).
 
 merge_commutative_test() ->
     Counter1 = {?TYPE, [{<<"5">>, 5}]},

--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -188,9 +188,10 @@ is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
 %% @doc Join decomposition for `state_gmap()'.
-%% @todo Check how to do this.
+%% @todo
 -spec join_decomposition(state_gmap()) -> [state_gmap()].
-join_decomposition({?TYPE, {_CType, _GMap}}) -> [].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
 
 -spec encode(state_type:format(), delta_or_state()) -> binary().
 encode(erlang, {?TYPE, _}=CRDT) ->
@@ -300,7 +301,7 @@ is_strict_inflation_test() ->
     ?assertNot(is_strict_inflation(Map1, Map3)).
 
 join_decomposition_test() ->
-    %% @todo.
+    %% @todo
     ok.
 
 encode_decode_test() ->

--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -225,7 +225,7 @@ query_test() ->
     ?assertEqual([], query(Map0)),
     ?assertEqual([{<<"key1">>, 15}, {<<"key2">>, 17}], query(Map1)).
 
-delta_increment_test() ->
+delta_apply_test() ->
     Map0 = new([?GCOUNTER_TYPE]),
     {ok, {?TYPE, {delta, Delta1}}} = delta_mutate({apply, <<"key1">>, increment}, 1, Map0),
     Map1 = merge({?TYPE, Delta1}, Map0),
@@ -241,7 +241,7 @@ delta_increment_test() ->
     ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
                                            {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map3).
 
-increment_test() ->
+apply_test() ->
     Map0 = new([?GCOUNTER_TYPE]),
     {ok, Map1} = mutate({apply, <<"key1">>, increment}, 1, Map0),
     {ok, Map2} = mutate({apply, <<"key1">>, increment}, 2, Map1),

--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -86,9 +86,10 @@ mutate(Op, Actor, {?TYPE, _}=CRDT) ->
     state_type:mutate(Op, Actor, CRDT).
 
 %% @doc Delta-mutate a `state_gmap()'.
-%%      The first argument can only be a pair where the first
-%%      component is a key, and the second is the operation
-%%      to be performed on the correspondent value of that key.
+%%      The first argument can only be a triple where the first
+%%      component `apply`, the second is a key, and the third is the
+%%      operation to be performed on the correspondent value of that
+%%      key.
 -spec delta_mutate(state_gmap_op(), type:id(), state_gmap()) ->
     {ok, delta_state_gmap()}.
 delta_mutate({apply, Key, Op}, Actor, {?TYPE, {CType, GMap}}) ->
@@ -150,7 +151,7 @@ equal({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
     end,
     orddict_ext:equal(GMap1, GMap2, Fun).
 
-%% @doc Check if a GMap is bottom
+%% @doc Check if a `state_gmap()' is bottom
 -spec is_bottom(delta_or_state()) -> boolean().
 is_bottom({?TYPE, {delta, GMap}}) ->
     is_bottom({?TYPE, GMap});

--- a/src/state_gset.erl
+++ b/src/state_gset.erl
@@ -216,8 +216,8 @@ merge_idempotent_test() ->
     Set2 = {?TYPE, [<<"a">>, <<"b">>]},
     Set3 = merge(Set1, Set1),
     Set4 = merge(Set2, Set2),
-    ?assertEqual({?TYPE, [<<"a">>]}, Set3),
-    ?assertEqual({?TYPE, [<<"a">>, <<"b">>]}, Set4).
+    ?assertEqual(Set1, Set3),
+    ?assertEqual(Set2, Set4).
 
 merge_commutative_test() ->
     Set1 = {?TYPE, [<<"a">>]},

--- a/src/state_lexcounter.erl
+++ b/src/state_lexcounter.erl
@@ -200,9 +200,10 @@ is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
     state_type:is_strict_inflation(CRDT1, CRDT2).
 
 %% @doc Join decomposition for `state_lexcounter()'.
-%% @todo Check how to do this.
+%% @todo
 -spec join_decomposition(state_lexcounter()) -> [state_lexcounter()].
-join_decomposition({?TYPE, _LexCounter}) -> [].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
 
 -spec encode(state_type:format(), delta_or_state()) -> binary().
 encode(erlang, {?TYPE, _}=CRDT) ->

--- a/src/state_lwwregister.erl
+++ b/src/state_lwwregister.erl
@@ -54,9 +54,9 @@
 -opaque state_lwwregister() :: {?TYPE, payload()}.
 -opaque delta_state_lwwregister() :: {?TYPE, {delta, payload()}}.
 -type delta_or_state() :: state_lwwregister() | delta_state_lwwregister().
+-type payload() :: {timestamp(), value()}.
 -type timestamp() :: non_neg_integer().
 -type value() :: term().
--type payload() :: {timestamp(), value()}.
 -type state_lwwregister_op() :: {set, timestamp(), value()}.
 
 %% @doc Create a new, empty `state_lwwregister()'

--- a/src/state_lwwregister.erl
+++ b/src/state_lwwregister.erl
@@ -21,7 +21,7 @@
 %% @doc LWWRegister.
 %%      We assume timestamp are unique, totally ordered and consistent
 %%      with causal order. We use integers as timestamps.
-%%      When using this, make sure you provide globally unique 
+%%      When using this, make sure you provide globally unique
 %%      timestamps.
 %%
 %% @reference Marc Shapiro, Nuno Preguiça, Carlos Baquero and Marek Zawirsk

--- a/src/state_lwwregister.erl
+++ b/src/state_lwwregister.erl
@@ -1,6 +1,5 @@
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/state_lwwregister.erl
+++ b/src/state_lwwregister.erl
@@ -1,0 +1,264 @@
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc LWWRegister.
+%%      We assume timestamp are unique, totally ordered and consistent
+%%      with causal order. We use integers as timestamps.
+%%      When using this, make sure you provide globally unique 
+%%      timestamps.
+%%
+%% @reference Marc Shapiro, Nuno Preguiça, Carlos Baquero and Marek Zawirsk
+%%      A comprehensive study of Convergent and Commutative Replicated Data Types (2011)
+%%      [http://hal.upmc.fr/file/index/docid/555588/filename/techreport.pdf]
+%%
+%% @reference Carlos Baquero
+%%      delta-enabled-crdts C++ library
+%%      [https://github.com/CBaquero/delta-enabled-crdts]
+
+-module(state_lwwregister).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-behaviour(type).
+-behaviour(state_type).
+
+-define(TYPE, ?MODULE).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([new/0, new/1, new_delta/0, new_delta/1, is_delta/1]).
+-export([mutate/3, delta_mutate/3, merge/2]).
+-export([query/1, equal/2, is_bottom/1, is_inflation/2, is_strict_inflation/2]).
+-export([join_decomposition/1]).
+-export([encode/2, decode/2]).
+
+-export_type([state_lwwregister/0, delta_state_lwwregister/0, state_lwwregister_op/0]).
+
+-opaque state_lwwregister() :: {?TYPE, payload()}.
+-opaque delta_state_lwwregister() :: {?TYPE, {delta, payload()}}.
+-type delta_or_state() :: state_lwwregister() | delta_state_lwwregister().
+-type timestamp() :: non_neg_integer().
+-type value() :: term().
+-type payload() :: {timestamp(), value()}.
+-type state_lwwregister_op() :: {set, timestamp(), value()}.
+
+%% @doc Create a new, empty `state_lwwregister()'
+-spec new() -> state_lwwregister().
+new() ->
+    {?TYPE, {0, undefined}}.
+
+%% @doc Create a new, empty `state_lwwregister()'
+-spec new([term()]) -> state_lwwregister().
+new([]) ->
+    new().
+
+-spec new_delta() -> delta_state_lwwregister().
+new_delta() ->
+    state_type:new_delta(?TYPE).
+
+-spec new_delta([term()]) -> delta_state_lwwregister().
+new_delta([]) ->
+    new_delta().
+
+-spec is_delta(delta_or_state()) -> boolean().
+is_delta({?TYPE, _}=CRDT) ->
+    state_type:is_delta(CRDT).
+
+%% @doc Mutate a `state_lwwregister()'.
+-spec mutate(state_lwwregister_op(), type:id(), state_lwwregister()) ->
+    {ok, state_lwwregister()}.
+mutate(Op, Actor, {?TYPE, _Register}=CRDT) ->
+    state_type:mutate(Op, Actor, CRDT).
+
+%% @doc Delta-mutate a `state_lwwregister()'.
+%%      The first argument can only be `{set, timestamp(), value()}'.
+%%      The second argument is the replica id (unused).
+%%      The third argument is the `state_lwwregister()' to be inflated.
+-spec delta_mutate(state_lwwregister_op(), type:id(), state_lwwregister()) ->
+    {ok, delta_state_lwwregister()}.
+delta_mutate({set, Timestamp, Value}, _Actor, {?TYPE, _Register}) when is_integer(Timestamp) ->
+    {ok, {?TYPE, {delta, {Timestamp, Value}}}}.
+
+%% @doc Returns the value of the `state_lwwregister()'.
+-spec query(state_lwwregister()) -> value().
+query({?TYPE, {_Timestamp, Value}}) ->
+    Value.
+
+%% @doc Merge two `state_lwwregister()'.
+%%      The result is the set union of both sets in the
+%%      `state_lwwregister()' passed as argument.
+-spec merge(delta_or_state(), delta_or_state()) -> delta_or_state().
+merge({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    MergeFun = fun({?TYPE, {Timestamp1, Value1}}, {?TYPE, {Timestamp2, Value2}}) ->
+        Register = case Timestamp1 > Timestamp2 of
+            true ->
+                {Timestamp1, Value1};
+            false ->
+                {Timestamp2, Value2}
+        end,
+        {?TYPE, Register}
+    end,
+    state_type:merge(CRDT1, CRDT2, MergeFun).
+
+%% @doc Equality for `state_lwwregister()'.
+-spec equal(state_lwwregister(), state_lwwregister()) -> boolean().
+equal({?TYPE, Register1}, {?TYPE, Register2}) ->
+    Register1 == Register2.
+
+%% @doc Check if a Register is bottom.
+-spec is_bottom(delta_or_state()) -> boolean().
+is_bottom({?TYPE, {delta, Register}}) ->
+    is_bottom({?TYPE, Register});
+is_bottom({?TYPE, _}=CRDT) ->
+    CRDT == new().
+
+%% @doc Given two `state_lwwregister()', check if the second is an inflation
+%%      of the first.
+%%      The second `state_lwwregister()' it has a higher timestamp or the same
+%%      timstamp (and in this case, they are equal).
+-spec is_inflation(delta_or_state(), state_lwwregister()) -> boolean().
+is_inflation({?TYPE, {delta, Register1}}, {?TYPE, Register2}) ->
+    is_inflation({?TYPE, Register1}, {?TYPE, Register2});
+is_inflation({?TYPE, {Timestamp1, _}}, {?TYPE, {Timestamp2, _}}) ->
+    Timestamp2 >= Timestamp1.
+
+%% @doc Check for strict inflation.
+-spec is_strict_inflation(delta_or_state(), state_lwwregister()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Register1}}, {?TYPE, Register2}) ->
+    is_strict_inflation({?TYPE, Register1}, {?TYPE, Register2});
+is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_strict_inflation(CRDT1, CRDT2).
+
+%% @doc Join decomposition for `state_lwwregister()'.
+-spec join_decomposition(state_lwwregister()) -> [state_lwwregister()].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
+
+-spec encode(state_type:format(), delta_or_state()) -> binary().
+encode(erlang, {?TYPE, _}=CRDT) ->
+    erlang:term_to_binary(CRDT).
+
+-spec decode(state_type:format(), binary()) -> delta_or_state().
+decode(erlang, Binary) ->
+    {?TYPE, _} = CRDT = erlang:binary_to_term(Binary),
+    CRDT.
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+new_test() ->
+    Bottom = {0, undefined},
+    ?assertEqual({?TYPE, Bottom}, new()),
+    ?assertEqual({?TYPE, {delta, Bottom}}, new_delta()).
+
+query_test() ->
+    Register0 = new(),
+    Register1 = {?TYPE, {1234, "a"}},
+    ?assertEqual(undefined, query(Register0)),
+    ?assertEqual("a", query(Register1)).
+
+delta_set_test() ->
+    Actor = 1,
+    Register0 = new(),
+    {ok, {?TYPE, {delta, Delta1}}} = delta_mutate({set, 1234, "a"}, Actor, Register0),
+    Register1 = merge({?TYPE, Delta1}, Register0),
+    {ok, {?TYPE, {delta, Delta2}}} = delta_mutate({set, 1235, "b"}, Actor, Register1),
+    Register2 = merge({?TYPE, Delta2}, Register1),
+    ?assertEqual({?TYPE, {1234, "a"}}, {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {1234, "a"}}, Register1),
+    ?assertEqual({?TYPE, {1235, "b"}}, {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {1235, "b"}}, Register2).
+
+set_test() ->
+    Actor = 1,
+    Register0 = new(),
+    {ok, Register1} = mutate({set, 1234, "a"}, Actor, Register0),
+    {ok, Register2} = mutate({set, 1235, "b"}, Actor, Register1),
+    ?assertEqual({?TYPE, {1234, "a"}}, Register1),
+    ?assertEqual({?TYPE, {1235, "b"}}, Register2).
+
+merge_idempotent_test() ->
+    Register1 = {?TYPE, {1234, "a"}},
+    Register2 = {?TYPE, {1235, "b"}},
+    Register3 = merge(Register1, Register1),
+    Register4 = merge(Register2, Register2),
+    ?assertEqual(Register1, Register3),
+    ?assertEqual(Register2, Register4).
+
+merge_commutative_test() ->
+    Register1 = {?TYPE, {1234, "a"}},
+    Register2 = {?TYPE, {1235, "b"}},
+    Register3 = merge(Register1, Register2),
+    Register4 = merge(Register2, Register1),
+    ?assertEqual(Register2, Register3),
+    ?assertEqual(Register2, Register4).
+
+equal_test() ->
+    Register1 = {?TYPE, {1234, "a"}},
+    Register2 = {?TYPE, {1235, "b"}},
+    ?assert(equal(Register1, Register1)),
+    ?assertNot(equal(Register1, Register2)).
+
+is_bottom_test() ->
+    Register0 = new(),
+    Register1 = {?TYPE, {1234, "a"}},
+    ?assert(is_bottom(Register0)),
+    ?assertNot(is_bottom(Register1)).
+
+is_inflation_test() ->
+    Register1 = {?TYPE, {1234, "a"}},
+    DeltaRegister1 = {?TYPE, {delta, {1234, "a"}}},
+    Register2 =  {?TYPE, {1235, "b"}},
+    ?assert(is_inflation(Register1, Register1)),
+    ?assert(is_inflation(Register1, Register2)),
+    ?assert(is_inflation(DeltaRegister1, Register1)),
+    ?assert(is_inflation(DeltaRegister1, Register2)),
+    ?assertNot(is_inflation(Register2, Register1)),
+    %% check inflation with merge
+    ?assert(state_type:is_inflation(Register1, Register1)),
+    ?assert(state_type:is_inflation(Register1, Register2)),
+    ?assertNot(state_type:is_inflation(Register2, Register1)).
+
+is_strict_inflation_test() ->
+    Register1 =  {?TYPE, {1234, "a"}},
+    DeltaRegister1 = {?TYPE, {delta, {1234, "a"}}},
+    Register2 =  {?TYPE, {1235, "b"}},
+    ?assertNot(is_strict_inflation(Register1, Register1)),
+    ?assert(is_strict_inflation(Register1, Register2)),
+    ?assertNot(is_strict_inflation(DeltaRegister1, Register1)),
+    ?assert(is_strict_inflation(DeltaRegister1, Register2)),
+    ?assertNot(is_strict_inflation(Register2, Register1)).
+
+join_decomposition_test() ->
+    Register =  {?TYPE, {1234, "a"}},
+    Decomp = join_decomposition(Register),
+    ?assertEqual([Register], Decomp).
+
+encode_decode_test() ->
+    Register =  {?TYPE, {1234, "a"}},
+    Binary = encode(erlang, Register),
+    ERegister = decode(erlang, Binary),
+    ?assertEqual(Register, ERegister).
+
+-endif.

--- a/src/state_max_int.erl
+++ b/src/state_max_int.erl
@@ -184,8 +184,8 @@ merge_idempotent_test() ->
     MaxInt2 = {?TYPE, 17},
     MaxInt3 = merge(MaxInt1, MaxInt1),
     MaxInt4 = merge(MaxInt2, MaxInt2),
-    ?assertEqual({?TYPE, 1}, MaxInt3),
-    ?assertEqual({?TYPE, 17}, MaxInt4).
+    ?assertEqual(MaxInt1, MaxInt3),
+    ?assertEqual(MaxInt2, MaxInt4).
 
 merge_commutative_test() ->
     MaxInt1 = {?TYPE, 1},

--- a/src/state_mvregister.erl
+++ b/src/state_mvregister.erl
@@ -93,7 +93,7 @@ delta_mutate({set, {CRDTType, _}=CRDTValue}, Actor, {?TYPE, {{{dot_fun, CRDTType
 
     EmptyDotFun = dot_fun:new(),
     DeltaDotStore = dot_fun:store(NextDot, CRDTValue, EmptyDotFun),
-    DeltaCausalContext0 = dot_fun:to_causal_context(DotStore),
+    DeltaCausalContext0 = causal_context:to_causal_context(DotStore),
     DeltaCausalContext1 = causal_context:add_dot(NextDot, DeltaCausalContext0),
 
     Delta = {DeltaDotStore, DeltaCausalContext1},

--- a/src/state_mvregister.erl
+++ b/src/state_mvregister.erl
@@ -1,0 +1,491 @@
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc Multi-Value Register CRDT.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(state_mvregister).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-include("state_type.hrl").
+
+-behaviour(type).
+-behaviour(state_type).
+
+-define(TYPE, ?MODULE).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([new/0, new/1, new_delta/0, new_delta/1, is_delta/1]).
+-export([mutate/3, delta_mutate/3, merge/2]).
+-export([query/1, equal/2, is_bottom/1, is_inflation/2, is_strict_inflation/2]).
+-export([join_decomposition/1]).
+-export([encode/2, decode/2]).
+
+-export_type([state_mvregister/0, delta_state_mvregister/0, state_mvregister_op/0]).
+
+-opaque state_mvregister() :: {?TYPE, payload()}.
+-opaque delta_state_mvregister() :: {?TYPE, {delta, payload()}}.
+-type delta_or_state() :: state_mvregister() | delta_state_mvregister().
+-type payload() :: state_causal_type:causal_crdt().
+-type state_mvregister_op() :: {set, state_type:crdt()}.
+
+%% @doc Create a new, empty `state_mvregister()'
+-spec new() -> state_mvregister().
+new() ->
+    new([?MAX_INT_TYPE]).
+
+%% @doc Create a new, empty `state_mvregister()'
+-spec new([term()]) -> state_mvregister().
+new([CRDTType]) ->
+    {?TYPE, state_causal_type:new({dot_fun, CRDTType})}.
+
+-spec new_delta() -> delta_state_mvregister().
+new_delta() ->
+    new_delta([?MAX_INT_TYPE]).
+
+-spec new_delta([term()]) -> delta_state_mvregister().
+new_delta(Args) ->
+    state_type:new_delta(?TYPE, Args).
+
+-spec is_delta(delta_or_state()) -> boolean().
+is_delta({?TYPE, _}=CRDT) ->
+    state_type:is_delta(CRDT).
+
+%% @doc Mutate a `state_mvregister()'.
+-spec mutate(state_mvregister_op(), type:id(), state_mvregister()) ->
+    {ok, state_mvregister()}.
+mutate(Op, Actor, {?TYPE, _Register}=CRDT) ->
+    state_type:mutate(Op, Actor, CRDT).
+
+%% @doc Delta-mutate a `state_mvregister()'.
+%%      The first argument can be:
+%%          - `{set, CRDTValue}'
+%%      The second argument is the replica id.
+%%      The third argument is the `state_mvregister()' to be inflated.
+-spec delta_mutate(state_mvregister_op(), type:id(), state_mvregister()) ->
+    {ok, delta_state_mvregister()}.
+
+%% @doc Sets `state_mvregister()' value.
+delta_mutate({set, {CRDTType, _}=CRDTValue}, Actor, {?TYPE, {{{dot_fun, CRDTType}, _}=DotStore, CausalContext}}) ->
+    NextDot = causal_context:next_dot(Actor, CausalContext),
+
+    EmptyDotFun = dot_fun:new(),
+    DeltaDotStore = dot_fun:store(NextDot, CRDTValue, EmptyDotFun),
+    DeltaCausalContext0 = dot_fun:to_causal_context(DotStore),
+    DeltaCausalContext1 = causal_context:add_dot(NextDot, DeltaCausalContext0),
+
+    Delta = {DeltaDotStore, DeltaCausalContext1},
+    {ok, {?TYPE, {delta, Delta}}}.
+
+%% @doc Returns the value of the `state_mvregister()'.
+-spec query(state_mvregister()) -> [state_type:crdt()].
+query({?TYPE, {DotStore, _CausalContext}}) ->
+    Dots = dot_fun:fetch_keys(DotStore),
+    lists:foldl(
+        fun(Dot, QueryResult) ->
+            Value = dot_fun:fetch(Dot, DotStore),
+            [Value | QueryResult]
+        end,
+        [],
+        Dots
+    ).
+
+%% @doc Merge two `state_mvregister()'.
+%%      Merging is handled by the `merge' function in
+%%      `state_causal_type' common library.
+-spec merge(delta_or_state(), delta_or_state()) -> delta_or_state().
+merge({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    MergeFun = fun({?TYPE, Register1}, {?TYPE, Register2}) ->
+        Register = state_causal_type:merge(Register1, Register2),
+        {?TYPE, Register}
+    end,
+    state_type:merge(CRDT1, CRDT2, MergeFun).
+
+%% @doc Equality for `state_mvregister()'.
+%%      Since everything is ordered, == should work.
+-spec equal(state_mvregister(), state_mvregister()) -> boolean().
+equal({?TYPE, Register1}, {?TYPE, Register2}) ->
+    Register1 == Register2.
+
+%% @doc Check if an `state_mvregister()' is bottom.
+-spec is_bottom(delta_or_state()) -> boolean().
+is_bottom({?TYPE, {delta, Register}}) ->
+    is_bottom({?TYPE, Register});
+is_bottom({?TYPE, _}=CRDT) ->
+    CRDT == new().
+
+%% @doc Given two `state_mvregister()', check if the second is and inflation of the first.
+%% @todo
+-spec is_inflation(delta_or_state(), state_mvregister()) -> boolean().
+is_inflation({?TYPE, {delta, Register1}}, {?TYPE, Register2}) ->
+    is_inflation({?TYPE, Register1}, {?TYPE, Register2});
+is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_inflation(CRDT1, CRDT2).
+
+%% @doc Check for strict inflation.
+-spec is_strict_inflation(delta_or_state(), state_mvregister()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Register1}}, {?TYPE, Register2}) ->
+    is_strict_inflation({?TYPE, Register1}, {?TYPE, Register2});
+is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_strict_inflation(CRDT1, CRDT2).
+
+%% @doc Join decomposition for `state_mvregister()'.
+%% @todo
+-spec join_decomposition(state_mvregister()) -> [state_mvregister()].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
+
+-spec encode(state_type:format(), delta_or_state()) -> binary().
+encode(erlang, {?TYPE, _}=CRDT) ->
+    erlang:term_to_binary(CRDT).
+
+-spec decode(state_type:format(), binary()) -> delta_or_state().
+decode(erlang, Binary) ->
+    {?TYPE, _} = CRDT = erlang:binary_to_term(Binary),
+    CRDT.
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+new_test() ->
+    ?assertEqual({?TYPE, {{{dot_fun, ?MAX_INT_TYPE}, orddict:new()}, ordsets:new()}},
+                 new()),
+    ?assertEqual({?TYPE, {delta, {{{dot_fun, ?MAX_INT_TYPE}, orddict:new()}, ordsets:new()}}},
+                 new_delta()).
+
+query_test() ->
+    Register0 = new(),
+    Register1 = {?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{a, 2}, {?MAX_INT_TYPE, 17}}]},
+            [{a, 1}, {a, 2}]
+        }
+    },
+    ?assertEqual([], query(Register0)),
+    ?assertEqual([{?MAX_INT_TYPE, 17}], query(Register1)).
+
+delta_mutate_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register0 = new(),
+    {ok, {?TYPE, {delta, Delta1}}} = delta_mutate({set, Value1}, ActorOne, Register0),
+    Register1 = merge({?TYPE, Delta1}, Register0),
+    {ok, {?TYPE, {delta, Delta2}}} = delta_mutate({set, Value2}, ActorTwo, Register1),
+    Register2 = merge({?TYPE, Delta2}, Register1),
+    {ok, {?TYPE, {delta, Delta3}}} = delta_mutate({set, Value1}, ActorTwo, Register2),
+    Register3 = merge({?TYPE, Delta3}, Register2),
+
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorOne, 1}, Value1}]},
+            [{ActorOne, 1}]
+        }},
+        {?TYPE, Delta1}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorOne, 1}, Value1}]},
+            [{ActorOne, 1}]
+        }},
+        Register1
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorTwo, 1}, Value2}]},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        {?TYPE, Delta2}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorTwo, 1}, Value2}]},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        Register2
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorTwo, 2}, Value1}]},
+            [{ActorTwo, 1}, {ActorTwo, 2}]
+        }},
+        {?TYPE, Delta3}
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorTwo, 2}, Value1}]},
+            [{ActorOne, 1}, {ActorTwo, 1}, {ActorTwo, 2}]
+        }},
+        Register3
+    ).
+
+mutate_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register0 = new(),
+    {ok, Register1} = mutate({set, Value1}, ActorOne, Register0),
+    {ok, Register2} = mutate({set, Value2}, ActorTwo, Register1),
+    {ok, Register3} = mutate({set, Value1}, ActorTwo, Register2),
+
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorOne, 1}, Value1}]},
+            [{ActorOne, 1}]
+        }},
+        Register1
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorTwo, 1}, Value2}]},
+            [{ActorOne, 1}, {ActorTwo, 1}]
+        }},
+        Register2
+    ),
+    ?assertEqual({?TYPE,
+        {
+            {{dot_fun, ?MAX_INT_TYPE}, [{{ActorTwo, 2}, Value1}]},
+            [{ActorOne, 1}, {ActorTwo, 1}, {ActorTwo, 2}]
+        }},
+        Register3
+    ).
+
+merge_idempontent_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register1 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}]
+                    }, 
+                    [{ActorOne, 1}]
+                }},
+    Register2 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorOne, 1}, {ActorTwo, 1}]
+                }},
+    Register3 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorTwo, 1}]
+                }},
+    Register4 = merge(Register1, Register1),
+    Register5 = merge(Register2, Register2),
+    Register6 = merge(Register3, Register3),
+    ?assertEqual(Register1, Register4),
+    ?assertEqual(Register2, Register5),
+    ?assertEqual(Register3, Register6).
+
+merge_commutative_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register1 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}]
+                    }, 
+                    [{ActorOne, 1}]
+                }},
+    Register2 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorOne, 1}, {ActorTwo, 1}]
+                }},
+    Register3 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorTwo, 1}]
+                }},
+    Register4 = merge(Register1, Register2),
+    Register5 = merge(Register2, Register1),
+    Register6 = merge(Register1, Register3),
+    Register7 = merge(Register3, Register1),
+    Register8 = merge(Register2, Register3),
+    Register9 = merge(Register3, Register2),
+    Register10 = merge(Register1, merge(Register2, Register3)),
+    Register1_2 = Register2,
+    Register1_3 = Register2,
+    Register2_3 = Register2,
+    ?assertEqual(Register1_2, Register4),
+    ?assertEqual(Register1_2, Register5),
+    ?assertEqual(Register1_3, Register6),
+    ?assertEqual(Register1_3, Register7),
+    ?assertEqual(Register2_3, Register8),
+    ?assertEqual(Register2_3, Register9),
+    ?assertEqual(Register1_3, Register10).
+
+equal_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register1 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}]
+                    }, 
+                    [{ActorOne, 1}]
+                }},
+    Register2 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorOne, 1}, {ActorTwo, 1}]
+                }},
+    Register3 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorTwo, 1}]
+                }},
+    ?assert(equal(Register1, Register1)),
+    ?assert(equal(Register2, Register2)),
+    ?assert(equal(Register3, Register3)),
+    ?assertNot(equal(Register1, Register2)),
+    ?assertNot(equal(Register1, Register3)),
+    ?assertNot(equal(Register2, Register3)).
+
+is_bottom_test() ->
+    Register0 = new(),
+    Register1 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{1, 1}, {?MAX_INT_TYPE, 17}}]
+                    }, 
+                    [{1, 1}]
+                }},
+    ?assert(is_bottom(Register0)),
+    ?assertNot(is_bottom(Register1)).
+
+is_inflation_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register1 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}]
+                    }, 
+                    [{ActorOne, 1}]
+                }},
+    Register2 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorOne, 1}, {ActorTwo, 1}]
+                }},
+    Register3 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorTwo, 1}]
+                }},
+    ?assert(is_inflation(Register1, Register1)),
+    ?assert(is_inflation(Register1, Register2)),
+    ?assertNot(is_inflation(Register2, Register1)),
+    ?assertNot(is_inflation(Register1, Register3)),
+    ?assertNot(is_inflation(Register2, Register3)),
+    ?assert(is_inflation(Register3, Register2)),
+    %% check inflation with merge
+    ?assert(state_type:is_inflation(Register1, Register1)),
+    ?assert(state_type:is_inflation(Register1, Register2)),
+    ?assertNot(state_type:is_inflation(Register2, Register1)),
+    ?assertNot(state_type:is_inflation(Register1, Register3)),
+    ?assertNot(state_type:is_inflation(Register2, Register3)),
+    ?assert(state_type:is_inflation(Register3, Register2)).
+
+is_strict_inflation_test() ->
+    Value1 = {?MAX_INT_TYPE, 17},
+    Value2 = {?MAX_INT_TYPE, 23},
+    ActorOne = 1,
+    ActorTwo = 2,
+    Register1 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}]
+                    }, 
+                    [{ActorOne, 1}]
+                }},
+    Register2 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorOne, 1}, {ActorTwo, 1}]
+                }},
+    Register3 = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{ActorTwo, 1}, Value2}]
+                    }, 
+                    [{ActorTwo, 1}]
+                }},
+    ?assertNot(is_strict_inflation(Register1, Register1)),
+    ?assert(is_strict_inflation(Register1, Register2)),
+    ?assertNot(is_strict_inflation(Register2, Register1)),
+    ?assertNot(is_strict_inflation(Register1, Register3)),
+    ?assertNot(is_strict_inflation(Register2, Register3)),
+    ?assert(is_strict_inflation(Register3, Register2)).
+
+join_decomposition_test() ->
+    %% @todo
+    ok.
+
+encode_decode_test() ->
+    Register = {?TYPE, {
+                    {
+                        {dot_fun, ?MAX_INT_TYPE}, 
+                        [{{1, 1}, {?MAX_INT_TYPE, 17}}]
+                    }, 
+                    [{1, 1}]
+                }},
+    Binary = encode(erlang, Register),
+    ERegister = decode(erlang, Binary),
+    ?assertEqual(Register, ERegister).
+
+-endif.

--- a/src/state_mvregister.erl
+++ b/src/state_mvregister.erl
@@ -284,23 +284,23 @@ merge_idempontent_test() ->
     ActorTwo = 2,
     Register1 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}]
-                    }, 
+                    },
                     [{ActorOne, 1}]
                 }},
     Register2 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorOne, 1}, {ActorTwo, 1}]
                 }},
     Register3 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorTwo, 1}]
                 }},
     Register4 = merge(Register1, Register1),
@@ -317,23 +317,23 @@ merge_commutative_test() ->
     ActorTwo = 2,
     Register1 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}]
-                    }, 
+                    },
                     [{ActorOne, 1}]
                 }},
     Register2 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorOne, 1}, {ActorTwo, 1}]
                 }},
     Register3 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorTwo, 1}]
                 }},
     Register4 = merge(Register1, Register2),
@@ -361,23 +361,23 @@ equal_test() ->
     ActorTwo = 2,
     Register1 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}]
-                    }, 
+                    },
                     [{ActorOne, 1}]
                 }},
     Register2 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorOne, 1}, {ActorTwo, 1}]
                 }},
     Register3 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorTwo, 1}]
                 }},
     ?assert(equal(Register1, Register1)),
@@ -391,9 +391,9 @@ is_bottom_test() ->
     Register0 = new(),
     Register1 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{1, 1}, {?MAX_INT_TYPE, 17}}]
-                    }, 
+                    },
                     [{1, 1}]
                 }},
     ?assert(is_bottom(Register0)),
@@ -406,23 +406,23 @@ is_inflation_test() ->
     ActorTwo = 2,
     Register1 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}]
-                    }, 
+                    },
                     [{ActorOne, 1}]
                 }},
     Register2 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorOne, 1}, {ActorTwo, 1}]
                 }},
     Register3 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorTwo, 1}]
                 }},
     ?assert(is_inflation(Register1, Register1)),
@@ -446,23 +446,23 @@ is_strict_inflation_test() ->
     ActorTwo = 2,
     Register1 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}]
-                    }, 
+                    },
                     [{ActorOne, 1}]
                 }},
     Register2 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorOne, 1}, Value1}, {{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorOne, 1}, {ActorTwo, 1}]
                 }},
     Register3 = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{ActorTwo, 1}, Value2}]
-                    }, 
+                    },
                     [{ActorTwo, 1}]
                 }},
     ?assertNot(is_strict_inflation(Register1, Register1)),
@@ -479,9 +479,9 @@ join_decomposition_test() ->
 encode_decode_test() ->
     Register = {?TYPE, {
                     {
-                        {dot_fun, ?MAX_INT_TYPE}, 
+                        {dot_fun, ?MAX_INT_TYPE},
                         [{{1, 1}, {?MAX_INT_TYPE, 17}}]
-                    }, 
+                    },
                     [{1, 1}]
                 }},
     Binary = encode(erlang, Register),

--- a/src/state_ormap.erl
+++ b/src/state_ormap.erl
@@ -185,7 +185,7 @@ new_test() ->
 query_test() ->
     Actor = 1,
     Map0 = new([?AWSET_TYPE]),
-    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE}, 
+    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
                      [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
                       {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}},
                                                   {13, {dot_set, [{Actor, 3}]}}]}}]},

--- a/src/state_ormap.erl
+++ b/src/state_ormap.erl
@@ -1,0 +1,349 @@
+%%
+%% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+%% @doc ORMap CRDT.
+%%      Modeled as a dictionary where keys can be anything and the
+%%      values are causal-CRDTs.
+%%
+%% @reference Paulo Sérgio Almeida, Ali Shoker, and Carlos Baquero
+%%      Delta State Replicated Data Types (2016)
+%%      [http://arxiv.org/pdf/1603.01529v1.pdf]
+
+-module(state_ormap).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+-include("state_type.hrl").
+
+-behaviour(type).
+-behaviour(state_type).
+
+-define(TYPE, ?MODULE).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-export([new/0, new/1, new_delta/0, new_delta/1, is_delta/1]).
+-export([mutate/3, delta_mutate/3, merge/2]).
+-export([query/1, equal/2, is_bottom/1, is_inflation/2, is_strict_inflation/2]).
+-export([join_decomposition/1]).
+-export([encode/2, decode/2]).
+
+-export_type([state_ormap/0, delta_state_ormap/0, state_ormap_op/0]).
+
+-opaque state_ormap() :: {?TYPE, payload()}.
+-opaque delta_state_ormap() :: {?TYPE, {delta, payload()}}.
+-type delta_or_state() :: state_ormap() | delta_state_ormap().
+-type payload() :: state_causal_type:causal_crdt().
+-type key() :: term().
+-type key_op() :: term().
+-type state_ormap_op() :: {apply, key(), key_op()} |
+                          {rmv, key()}.
+
+%% @doc Create a new, empty `state_ormap()'.
+%%      By default the values are a AWSet Causal CRDT.
+-spec new() -> state_ormap().
+new() ->
+    new([?AWSET_TYPE]).
+
+%% @doc Create a new, empty `state_ormap()'
+-spec new([term()]) -> state_ormap().
+new([CType]) ->
+    {?TYPE, state_causal_type:new({dot_map, CType})}.
+
+-spec new_delta() -> delta_state_ormap().
+new_delta() ->
+    new_delta([?AWSET_TYPE]).
+
+-spec new_delta([term()]) -> delta_state_ormap().
+new_delta(Args) ->
+    state_type:new_delta(?TYPE, Args).
+
+-spec is_delta(delta_or_state()) -> boolean().
+is_delta({?TYPE, _}=CRDT) ->
+    state_type:is_delta(CRDT).
+
+%% @doc Mutate a `state_ormap()'.
+-spec mutate(state_ormap_op(), type:id(), state_ormap()) ->
+    {ok, state_ormap()}.
+mutate(Op, Actor, {?TYPE, _}=CRDT) ->
+    state_type:mutate(Op, Actor, CRDT).
+
+%% @doc Delta-mutate a `state_ormap()'.
+%%      The first argument can only be a pair where the first
+%%      component is a key, and the second is the operation
+%%      to be performed on the correspondent value of that key.
+-spec delta_mutate(state_ormap_op(), type:id(), state_ormap()) ->
+    {ok, delta_state_ormap()}.
+delta_mutate({apply, Key, Op}, Actor, {?TYPE, {{{dot_map, CType}, _}=DotMap, CausalContext}}) ->
+    {Type, _} = state_type:extract_args(CType),
+    SubDotStore = dot_map:fetch(Key, DotMap),
+    {ok, {Type, {delta, {DeltaSubDotStore, DeltaCausalContext}}}} = Type:delta_mutate(Op, Actor, {Type, {SubDotStore, CausalContext}}),
+    EmptyDotMap = dot_map:new(CType),
+    DeltaDotStore = dot_map:store(Key, DeltaSubDotStore, EmptyDotMap),
+
+    Delta = {DeltaDotStore, DeltaCausalContext},
+    {ok, {?TYPE, {delta, Delta}}}.
+
+%% @doc Returns the value of the `state_ormap()'.
+%%      This value is a dictionary where each key maps to the
+%%      result of `query/1' over the current value.
+-spec query(state_ormap()) -> term().
+query({?TYPE, {{{dot_map, CType}, _}=DotMap, CausalContext}}) ->
+    {Type, _Args} = state_type:extract_args(CType),
+
+    lists:foldl(
+        fun(Key, Result) ->
+            Value = dot_map:fetch(Key, DotMap),
+            orddict:store(Key, Type:query({Type, {Value, CausalContext}}), Result)
+        end,
+        orddict:new(),
+        dot_map:fetch_keys(DotMap)
+    ).
+
+%% @doc Merge two `state_ormap()'.
+%%      Merging is handled by the `merge' function in
+%%      `state_causal_type' common library.
+-spec merge(delta_or_state(), delta_or_state()) -> delta_or_state().
+merge({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    MergeFun = fun({?TYPE, ORMap1}, {?TYPE, ORMap2}) ->
+        Map = state_causal_type:merge(ORMap1, ORMap2),
+        {?TYPE, Map}
+    end,
+    state_type:merge(CRDT1, CRDT2, MergeFun).
+
+%% @doc Equality for `state_ormap()'.
+%%      Since everything is ordered, == should work.
+-spec equal(state_ormap(), state_ormap()) -> boolean().
+equal({?TYPE, ORMap1}, {?TYPE, ORMap2}) ->
+    ORMap1 == ORMap2.
+
+%% @doc Check if a `state_ormap()' is bottom
+-spec is_bottom(delta_or_state()) -> boolean().
+is_bottom({?TYPE, {delta, Map}}) ->
+    is_bottom({?TYPE, Map});
+is_bottom({?TYPE, _}=CRDT) ->
+    CRDT == new().
+
+%% @doc Given two `state_ormap()', check if the second is an inflation
+%%      of the first.
+%% @todo
+-spec is_inflation(delta_or_state(), state_ormap()) -> boolean().
+is_inflation({?TYPE, {delta, Map1}}, {?TYPE, Map2}) ->
+    is_inflation({?TYPE, Map1}, {?TYPE, Map2});
+is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_inflation(CRDT1, CRDT2).
+
+%% @doc Check for strict inflation.
+-spec is_strict_inflation(delta_or_state(), state_ormap()) -> boolean().
+is_strict_inflation({?TYPE, {delta, Map1}}, {?TYPE, Map2}) ->
+    is_strict_inflation({?TYPE, Map1}, {?TYPE, Map2});
+is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_strict_inflation(CRDT1, CRDT2).
+
+%% @doc Join decomposition for `state_ormap()'.
+%% @todo
+-spec join_decomposition(state_ormap()) -> [state_ormap()].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
+
+-spec encode(state_type:format(), delta_or_state()) -> binary().
+encode(erlang, {?TYPE, _}=CRDT) ->
+    erlang:term_to_binary(CRDT).
+
+-spec decode(state_type:format(), binary()) -> delta_or_state().
+decode(erlang, Binary) ->
+    {?TYPE, _} = CRDT = erlang:binary_to_term(Binary),
+    CRDT.
+
+
+%% ===================================================================
+%% EUnit tests
+%% ===================================================================
+-ifdef(TEST).
+
+new_test() ->
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE}, []}, []}}, new()),
+    ?assertEqual({?TYPE, {delta, {{{dot_map, ?AWSET_TYPE}, []}, []}}}, new_delta()).
+
+query_test() ->
+    Actor = 1,
+    Map0 = new([?AWSET_TYPE]),
+    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE}, 
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}},
+                                                  {13, {dot_set, [{Actor, 3}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+    ?assertEqual([], query(Map0)),
+    ?assertEqual([{"a", sets:from_list([17])}, {"b", sets:from_list([3, 13])}], query(Map1)).
+
+delta_apply_test() ->
+    Actor = 1,
+    Map0 = new([?AWSET_TYPE]),
+    {ok, {?TYPE, {delta, Delta1}}} = delta_mutate({apply, "b", {add, 3}}, Actor, Map0),
+    Map1 = merge({?TYPE, Delta1}, Map0),
+    {ok, {?TYPE, {delta, Delta2}}} = delta_mutate({apply, "a", {add, 17}}, Actor, Map1),
+    Map2 = merge({?TYPE, Delta2}, Map1),
+    {ok, {?TYPE, {delta, Delta3}}} = delta_mutate({apply, "b", {add, 13}}, Actor, Map2),
+    Map3 = merge({?TYPE, Delta3}, Map2),
+    {ok, {?TYPE, {delta, Delta4}}} = delta_mutate({apply, "b", {rmv, 3}}, Actor, Map3),
+    Map4 = merge({?TYPE, Delta4}, Map3),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+                 {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+                 Map1),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17,  {dot_set, [{Actor, 2}]}}]}}]},
+                   [{Actor, 2}]}},
+                 {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}]}},
+                 Map2),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{13,  {dot_set, [{Actor, 3}]}}]}}]},
+                   [{Actor, 3}]}},
+                 {?TYPE, Delta3}),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}},
+                                                  {13, {dot_set, [{Actor, 3}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+                 Map3),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, []}}]},
+                   [{Actor, 1}]}},
+                 {?TYPE, Delta4}),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{13, {dot_set, [{Actor, 3}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+                 Map4).
+
+apply_test() ->
+    Actor = 1,
+    Map0 = new([?AWSET_TYPE]),
+    {ok, Map1} = mutate({apply, "b", {add, 3}}, Actor, Map0),
+    {ok, Map2} = mutate({apply, "a", {add, 17}}, Actor, Map1),
+    {ok, Map3} = mutate({apply, "b", {add, 13}}, Actor, Map2),
+    {ok, Map4} = mutate({apply, "b", {rmv, 3}}, Actor, Map3),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+                 Map1),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}]}},
+                 Map2),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}},
+                                                  {13, {dot_set, [{Actor, 3}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+                 Map3),
+    ?assertEqual({?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{13, {dot_set, [{Actor, 3}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}, {Actor, 3}]}},
+                 Map4).
+
+equal_test() ->
+    Actor = "one",
+    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+    Map2 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17,  {dot_set, [{Actor, 2}]}}]}}]},
+                   [{Actor, 2}]}},
+    Map3 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}]}},
+    ?assert(equal(Map1, Map1)),
+    ?assertNot(equal(Map1, Map2)),
+    ?assertNot(equal(Map1, Map3)).
+
+is_bottom_test() ->
+    Actor = "one",
+    Map0 = new(),
+    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+    ?assert(is_bottom(Map0)),
+    ?assertNot(is_bottom(Map1)).
+
+is_inflation_test() ->
+    Actor = "1",
+    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+    Map2 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17,  {dot_set, [{Actor, 2}]}}]}}]},
+                   [{Actor, 2}]}},
+    Map3 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}]}},
+    ?assert(is_inflation(Map1, Map1)),
+    ?assertNot(is_inflation(Map1, Map2)),
+    ?assertNot(is_inflation(Map2, Map1)),
+    ?assert(is_inflation(Map1, Map3)),
+    ?assert(is_inflation(Map2, Map3)),
+    %% check inflation with merge
+    ?assert(state_type:is_inflation(Map1, Map1)),
+    ?assertNot(state_type:is_inflation(Map1, Map2)),
+    ?assertNot(state_type:is_inflation(Map2, Map1)),
+    ?assert(state_type:is_inflation(Map1, Map3)),
+    ?assert(state_type:is_inflation(Map2, Map3)).
+
+is_strict_inflation_test() ->
+    Actor = "1",
+    Map1 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"b", {{dot_map, dot_set}, [{3,  {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}]}},
+    Map2 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17,  {dot_set, [{Actor, 2}]}}]}}]},
+                   [{Actor, 2}]}},
+    Map3 = {?TYPE, {{{dot_map, ?AWSET_TYPE},
+                     [{"a", {{dot_map, dot_set}, [{17, {dot_set, [{Actor, 2}]}}]}},
+                      {"b", {{dot_map, dot_set}, [{3, {dot_set, [{Actor, 1}]}}]}}]},
+                   [{Actor, 1}, {Actor, 2}]}},
+    ?assertNot(is_strict_inflation(Map1, Map1)),
+    ?assertNot(is_strict_inflation(Map1, Map2)),
+    ?assertNot(is_strict_inflation(Map2, Map1)),
+    ?assert(is_strict_inflation(Map1, Map3)),
+    ?assert(is_strict_inflation(Map2, Map3)).
+
+join_decomposition_test() ->
+    %% @todo
+    ok.
+
+encode_decode_test() ->
+    Map = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
+    Binary = encode(erlang, Map),
+    EMap = decode(erlang, Binary),
+    ?assertEqual(Map, EMap).
+
+-endif.

--- a/src/state_orset.erl
+++ b/src/state_orset.erl
@@ -53,10 +53,10 @@
 -type element() :: term().
 -type token() :: term().
 -type state_orset_op() :: {add, element()} |
-                    {add_by_token, token(), element()} |
-                    {add_all, [element()]} |
-                    {rmv, element()} |
-                    {rmv_all, [element()]}.
+                          {add_by_token, token(), element()} |
+                          {add_all, [element()]} |
+                          {rmv, element()} |
+                          {rmv_all, [element()]}.
 
 %% @doc Create a new, empty `state_orset()'
 -spec new() -> state_orset().
@@ -135,7 +135,7 @@ delta_mutate({rmv, Elem}, _Actor, {?TYPE, ORSet}) ->
             {error, {precondition, {not_present, [Elem]}}}
     end;
 
-%% @doc Removes a list of elemenets passed as input.
+%% @doc Removes a list of elements passed as input.
 delta_mutate({rmv_all, Elems}, Actor, {?TYPE, _}=ORSet) ->
     {{?TYPE, DeltaGroup}, NotRemoved} = lists:foldl(
         fun(Elem, {DeltaGroupAcc, NotRemovedAcc}) ->

--- a/src/state_orset.erl
+++ b/src/state_orset.erl
@@ -372,9 +372,9 @@ merge_idempotent_test() ->
     Set4 = merge(Set1, Set1),
     Set5 = merge(Set2, Set2),
     Set6 = merge(Set3, Set3),
-    ?assertEqual({?TYPE, [{<<"a">>, [{<<"token1">>, false}]}]}, Set4),
-    ?assertEqual({?TYPE, [{<<"b">>, [{<<"token2">>, true}]}]}, Set5),
-    ?assertEqual({?TYPE, [{<<"a">>, [{<<"token1">>, true}]}, {<<"b">>, [{<<"token2">>, false}]}]}, Set6).
+    ?assertEqual(Set1, Set4),
+    ?assertEqual(Set2, Set5),
+    ?assertEqual(Set3, Set6).
 
 merge_commutative_test() ->
     Set1 = {?TYPE, [{<<"a">>, [{<<"token1">>, false}]}]},

--- a/src/state_pair.erl
+++ b/src/state_pair.erl
@@ -174,9 +174,10 @@ is_strict_inflation({?TYPE, {{FstType, _}=Fst1, {SndType, _}=Snd1}},
     (FstType:is_inflation(Fst1, Fst2) andalso SndType:is_strict_inflation(Snd1, Snd2)).
 
 %% @doc Join decomposition for `state_pair()'.
-%% @todo Check how to do this.
+%% @todo
 -spec join_decomposition(state_pair()) -> [state_pair()].
-join_decomposition({?TYPE, _Pair}) -> [].
+join_decomposition({?TYPE, _}=CRDT) ->
+    [CRDT].
 
 -spec encode(state_type:format(), delta_or_state()) -> binary().
 encode(erlang, {?TYPE, _}=CRDT) ->

--- a/src/state_pncounter.erl
+++ b/src/state_pncounter.erl
@@ -276,8 +276,8 @@ merge_idempotent_test() ->
     Counter2 = {?TYPE, [{<<"6">>, {6, 3}}, {<<"7">>, {7, 4}}]},
     Counter3 = merge(Counter1, Counter1),
     Counter4 = merge(Counter2, Counter2),
-    ?assertEqual({?TYPE, [{<<"5">>, {5, 2}}]}, Counter3),
-    ?assertEqual({?TYPE, [{<<"6">>, {6, 3}}, {<<"7">>, {7, 4}}]}, Counter4).
+    ?assertEqual(Counter1, Counter3),
+    ?assertEqual(Counter2, Counter4).
 
 merge_commutative_test() ->
     Counter1 = {?TYPE, [{<<"5">>, {5, 2}}]},

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -31,6 +31,7 @@
                       state_awset_ps |
                       state_bcounter |
                       state_boolean |
+                      state_ewflag |
                       state_gcounter |
                       state_gmap |
                       state_gset |

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -38,6 +38,7 @@
                       state_ivar |
                       state_lexcounter |
                       state_max_int |
+                      state_mvregister |
                       state_orset |
                       state_pair |
                       state_pncounter |

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -31,6 +31,7 @@
                       state_awset_ps |
                       state_bcounter |
                       state_boolean |
+                      state_dwflag |
                       state_ewflag |
                       state_gcounter |
                       state_gmap |

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -37,6 +37,7 @@
                       state_gset |
                       state_ivar |
                       state_lexcounter |
+                      state_lwwregister |
                       state_max_int |
                       state_mvregister |
                       state_orset |

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -40,6 +40,7 @@
                       state_lwwregister |
                       state_max_int |
                       state_mvregister |
+                      state_ormap |
                       state_orset |
                       state_pair |
                       state_pncounter |

--- a/src/type.erl
+++ b/src/type.erl
@@ -1,7 +1,5 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
-%% Copyright (c) 2007-2012 Basho Technologies, Inc.  All Rights Reserved.
 %%
 %% This file is provided to you under the Apache License,
 %% Version 2.0 (the "License"); you may not use this file

--- a/src/types.erl
+++ b/src/types.erl
@@ -1,4 +1,3 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
 %%

--- a/src/types_app.erl
+++ b/src/types_app.erl
@@ -1,4 +1,3 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
 %%

--- a/src/types_sup.erl
+++ b/src/types_sup.erl
@@ -1,4 +1,3 @@
-%% -------------------------------------------------------------------
 %%
 %% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
 %%

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -57,8 +57,7 @@ all() ->
         pair_with_gmap_and_pair_with_gcounter_and_gmap_test,
         pair_with_pair_with_gcounter_and_gmap_and_gmap_test,
         gmap_with_pair_test,
-        gmap_with_awset_test,
-        gmap_with_gmap_with_awset_test
+        maps_within_maps_test
     ].
 
 %% ===================================================================
@@ -382,33 +381,46 @@ gmap_with_pair_test(_Config) ->
     ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, true}, {?BOOLEAN_TYPE, true}}}}]}}, GMap3),
     ?assertEqual([{Actor, {true, true}}], Query).
 
-gmap_with_awset_test(_Config) ->
+maps_within_maps_test(_Config) ->
+    lists:foreach(
+        fun(MapType) ->
+            map_with_awset(MapType),
+            map_with_map_with_awset(MapType)
+        end,
+        [?GMAP_TYPE]
+    ).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+map_with_awset(MapType) ->
     Actor = "A",
     CType = ?AWSET_TYPE,
-    GMap0 = ?GMAP_TYPE:new([CType]),
-    {ok, GMap1} = ?GMAP_TYPE:mutate({"hello", {add, 3}}, Actor, GMap0),
-    {ok, GMap2} = ?GMAP_TYPE:mutate({"world", {add, 17}}, Actor, GMap1),
-    {ok, GMap3} = ?GMAP_TYPE:mutate({"hello", {add, 13}}, Actor, GMap2),
-    Query1 = ?GMAP_TYPE:query(GMap1),
-    Query2 = ?GMAP_TYPE:query(GMap2),
-    Query3 = ?GMAP_TYPE:query(GMap3),
+    Map0 = MapType:new([CType]),
+    {ok, Map1} = MapType:mutate({"hello", {add, 3}}, Actor, Map0),
+    {ok, Map2} = MapType:mutate({"world", {add, 17}}, Actor, Map1),
+    {ok, Map3} = MapType:mutate({"hello", {add, 13}}, Actor, Map2),
+    Query1 = MapType:query(Map1),
+    Query2 = MapType:query(Map2),
+    Query3 = MapType:query(Map3),
 
     ?assertEqual([{"hello", sets:from_list([3])}], Query1),
     ?assertEqual([{"hello", sets:from_list([3])}, {"world", sets:from_list([17])}], Query2),
     ?assertEqual([{"hello", sets:from_list([3, 13])}, {"world", sets:from_list([17])}], Query3).
 
-gmap_with_gmap_with_awset_test(_Config) ->
+map_with_map_with_awset(MapType) ->
     Actor = "A",
-    CType = {?GMAP_TYPE, [?AWSET_TYPE]},
-    GMap0 = ?GMAP_TYPE:new([CType]),
-    {ok, GMap1} = ?GMAP_TYPE:mutate({"hello", {"world_one", {add, 3}}}, Actor, GMap0),
-    {ok, GMap2} = ?GMAP_TYPE:mutate({"hello", {"world_two", {add, 7}}}, Actor, GMap1),
-    {ok, GMap3} = ?GMAP_TYPE:mutate({"world", {"hello", {add, 17}}}, Actor, GMap2),
-    {ok, GMap4} = ?GMAP_TYPE:mutate({"hello", {"world_one", {add, 13}}}, Actor, GMap3),
-    Query1 = ?GMAP_TYPE:query(GMap1),
-    Query2 = ?GMAP_TYPE:query(GMap2),
-    Query3 = ?GMAP_TYPE:query(GMap3),
-    Query4 = ?GMAP_TYPE:query(GMap4),
+    CType = {MapType, [?AWSET_TYPE]},
+    Map0 = MapType:new([CType]),
+    {ok, Map1} = MapType:mutate({"hello", {"world_one", {add, 3}}}, Actor, Map0),
+    {ok, Map2} = MapType:mutate({"hello", {"world_two", {add, 7}}}, Actor, Map1),
+    {ok, Map3} = MapType:mutate({"world", {"hello", {add, 17}}}, Actor, Map2),
+    {ok, Map4} = MapType:mutate({"hello", {"world_one", {add, 13}}}, Actor, Map3),
+    Query1 = MapType:query(Map1),
+    Query2 = MapType:query(Map2),
+    Query3 = MapType:query(Map3),
+    Query4 = MapType:query(Map4),
 
     ?assertEqual([{"hello", [{"world_one", sets:from_list([3])}]}], Query1),
     ?assertEqual([{"hello", [{"world_one", sets:from_list([3])}, {"world_two", sets:from_list([7])}]}], Query2),

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -57,7 +57,8 @@ all() ->
         pair_with_gmap_and_pair_with_gcounter_and_gmap_test,
         pair_with_pair_with_gcounter_and_gmap_and_gmap_test,
         gmap_with_pair_test,
-        maps_within_maps_test
+        maps_within_maps_test,
+        ormap_nested_rmv_test
     ].
 
 %% ===================================================================
@@ -389,6 +390,32 @@ maps_within_maps_test(_Config) ->
         end,
         [?GMAP_TYPE, ?ORMAP_TYPE]
     ).
+
+ormap_nested_rmv_test(_Config) ->
+    Actor = "A",
+    CType = {?ORMAP_TYPE, [?AWSET_TYPE]},
+    Map0 = ?ORMAP_TYPE:new([CType]),
+    {ok, Map1} = ?ORMAP_TYPE:mutate({apply, "hello", {apply, "world_one", {add, 3}}}, Actor, Map0),
+    {ok, Map2} = ?ORMAP_TYPE:mutate({apply, "hello", {apply, "world_two", {add, 7}}}, Actor, Map1),
+    {ok, Map3} = ?ORMAP_TYPE:mutate({apply, "world", {apply, "hello", {add, 17}}}, Actor, Map2),
+    {ok, Map4} = ?ORMAP_TYPE:mutate({apply, "hello", {rmv, "world_one"}}, Actor, Map3),
+    {ok, Map5} = ?ORMAP_TYPE:mutate({rmv, "world"}, Actor, Map4),
+    {ok, Map6} = ?ORMAP_TYPE:mutate({apply, "hello", {apply, "world_z", {add, 23}}}, Actor, Map5),
+    {ok, Map7} = ?ORMAP_TYPE:mutate({apply, "hello", {rmv, "world_two"}}, Actor, Map6),
+    {ok, Map8} = ?ORMAP_TYPE:mutate({apply, "hello", {rmv, "world_z"}}, Actor, Map7),
+    Query3 = ?ORMAP_TYPE:query(Map3),
+    Query4 = ?ORMAP_TYPE:query(Map4),
+    Query5 = ?ORMAP_TYPE:query(Map5),
+    Query6 = ?ORMAP_TYPE:query(Map6),
+    Query7 = ?ORMAP_TYPE:query(Map7),
+    Query8 = ?ORMAP_TYPE:query(Map8),
+
+    ?assertEqual([{"hello", [{"world_one", sets:from_list([3])}, {"world_two", sets:from_list([7])}]}, {"world", [{"hello", sets:from_list([17])}]}], Query3),
+    ?assertEqual([{"hello", [{"world_two", sets:from_list([7])}]}, {"world", [{"hello", sets:from_list([17])}]}], Query4),
+    ?assertEqual([{"hello", [{"world_two", sets:from_list([7])}]}], Query5),
+    ?assertEqual([{"hello", [{"world_two", sets:from_list([7])}, {"world_z", sets:from_list([23])}]}], Query6),
+    ?assertEqual([{"hello", [{"world_z", sets:from_list([23])}]}], Query7),
+    ?assertEqual([], Query8).
 
 %% ===================================================================
 %% Internal functions

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -387,7 +387,7 @@ maps_within_maps_test(_Config) ->
             map_with_awset(MapType),
             map_with_map_with_awset(MapType)
         end,
-        [?GMAP_TYPE]
+        [?GMAP_TYPE, ?ORMAP_TYPE]
     ).
 
 %% ===================================================================

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -262,7 +262,7 @@ pair_with_gcounter_and_gmap_test(_Config) ->
     Actor = "A",
     Pair0 = ?PAIR_TYPE:new([?GCOUNTER_TYPE, {?GMAP_TYPE, [?BOOLEAN_TYPE]}]),
     {ok, Pair1} = ?PAIR_TYPE:mutate({fst, increment}, Actor, Pair0),
-    {ok, Pair2} = ?PAIR_TYPE:mutate({snd, {Actor, true}}, Actor, Pair1),
+    {ok, Pair2} = ?PAIR_TYPE:mutate({snd, {apply, Actor, true}}, Actor, Pair1),
     {ok, Pair3} = ?PAIR_TYPE:mutate({fst, increment}, Actor, Pair2),
     Query = ?PAIR_TYPE:query(Pair3),
 
@@ -281,9 +281,9 @@ pair_with_gmap_and_pair_with_gcounter_and_gmap_test(_Config) ->
             {?GMAP_TYPE, [?BOOLEAN_TYPE]}
         ]}
     ]),
-    {ok, Pair1} = ?PAIR_TYPE:mutate({fst, {Actor, true}}, Actor, Pair0),
+    {ok, Pair1} = ?PAIR_TYPE:mutate({fst, {apply, Actor, true}}, Actor, Pair0),
     {ok, Pair2} = ?PAIR_TYPE:mutate({snd, {fst, increment}}, Actor, Pair1),
-    {ok, Pair3} = ?PAIR_TYPE:mutate({snd, {snd, {Actor, true}}}, Actor, Pair2),
+    {ok, Pair3} = ?PAIR_TYPE:mutate({snd, {snd, {apply, Actor, true}}}, Actor, Pair2),
     Query = ?PAIR_TYPE:query(Pair3),
 
     ?assertEqual({?PAIR_TYPE, {
@@ -328,9 +328,9 @@ pair_with_pair_with_gcounter_and_gmap_and_gmap_test(_Config) ->
         ]},
         {?GMAP_TYPE, [?BOOLEAN_TYPE]}
     ]),
-    {ok, Pair1} = ?PAIR_TYPE:mutate({snd, {Actor, true}}, Actor, Pair0),
+    {ok, Pair1} = ?PAIR_TYPE:mutate({snd, {apply, Actor, true}}, Actor, Pair0),
     {ok, Pair2} = ?PAIR_TYPE:mutate({fst, {fst, increment}}, Actor, Pair1),
-    {ok, Pair3} = ?PAIR_TYPE:mutate({fst, {snd, {Actor, true}}}, Actor, Pair2),
+    {ok, Pair3} = ?PAIR_TYPE:mutate({fst, {snd, {apply, Actor, true}}}, Actor, Pair2),
     Query = ?PAIR_TYPE:query(Pair3),
 
     ?assertEqual({?PAIR_TYPE, {
@@ -370,9 +370,9 @@ gmap_with_pair_test(_Config) ->
     Actor = "A",
     CType = {?PAIR_TYPE, [?BOOLEAN_TYPE, ?BOOLEAN_TYPE]},
     GMap0 = ?GMAP_TYPE:new([CType]),
-    {ok, GMap1} = ?GMAP_TYPE:mutate({Actor, {fst, true}}, Actor, GMap0),
-    {ok, GMap2} = ?GMAP_TYPE:mutate({Actor, {snd, true}}, Actor, GMap0),
-    {ok, GMap3} = ?GMAP_TYPE:mutate({Actor, {snd, true}}, Actor, GMap1),
+    {ok, GMap1} = ?GMAP_TYPE:mutate({apply, Actor, {fst, true}}, Actor, GMap0),
+    {ok, GMap2} = ?GMAP_TYPE:mutate({apply, Actor, {snd, true}}, Actor, GMap0),
+    {ok, GMap3} = ?GMAP_TYPE:mutate({apply, Actor, {snd, true}}, Actor, GMap1),
     Query = ?GMAP_TYPE:query(GMap3),
 
     ?assertEqual({?GMAP_TYPE, {CType, []}}, GMap0),
@@ -398,9 +398,9 @@ map_with_awset(MapType) ->
     Actor = "A",
     CType = ?AWSET_TYPE,
     Map0 = MapType:new([CType]),
-    {ok, Map1} = MapType:mutate({"hello", {add, 3}}, Actor, Map0),
-    {ok, Map2} = MapType:mutate({"world", {add, 17}}, Actor, Map1),
-    {ok, Map3} = MapType:mutate({"hello", {add, 13}}, Actor, Map2),
+    {ok, Map1} = MapType:mutate({apply, "hello", {add, 3}}, Actor, Map0),
+    {ok, Map2} = MapType:mutate({apply, "world", {add, 17}}, Actor, Map1),
+    {ok, Map3} = MapType:mutate({apply, "hello", {add, 13}}, Actor, Map2),
     Query1 = MapType:query(Map1),
     Query2 = MapType:query(Map2),
     Query3 = MapType:query(Map3),
@@ -413,10 +413,10 @@ map_with_map_with_awset(MapType) ->
     Actor = "A",
     CType = {MapType, [?AWSET_TYPE]},
     Map0 = MapType:new([CType]),
-    {ok, Map1} = MapType:mutate({"hello", {"world_one", {add, 3}}}, Actor, Map0),
-    {ok, Map2} = MapType:mutate({"hello", {"world_two", {add, 7}}}, Actor, Map1),
-    {ok, Map3} = MapType:mutate({"world", {"hello", {add, 17}}}, Actor, Map2),
-    {ok, Map4} = MapType:mutate({"hello", {"world_one", {add, 13}}}, Actor, Map3),
+    {ok, Map1} = MapType:mutate({apply, "hello", {apply, "world_one", {add, 3}}}, Actor, Map0),
+    {ok, Map2} = MapType:mutate({apply, "hello", {apply, "world_two", {add, 7}}}, Actor, Map1),
+    {ok, Map3} = MapType:mutate({apply, "world", {apply, "hello", {add, 17}}}, Actor, Map2),
+    {ok, Map4} = MapType:mutate({apply, "hello", {apply, "world_one", {add, 13}}}, Actor, Map3),
     Query1 = MapType:query(Map1),
     Query2 = MapType:query(Map2),
     Query3 = MapType:query(Map3),

--- a/test/state_type_semantics_SUITE.erl
+++ b/test/state_type_semantics_SUITE.erl
@@ -57,7 +57,8 @@ all() ->
 
 flag_test(_Config) ->
     List = [
-        {state_ewflag, true}
+        {state_ewflag, true},
+        {state_dwflag, false}
     ],
 
     lists:foreach(

--- a/test/state_type_semantics_SUITE.erl
+++ b/test/state_type_semantics_SUITE.erl
@@ -1,0 +1,100 @@
+%% -------------------------------------------------------------------
+%%
+%% Copyright (c) 2016 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+%%
+
+-module(state_type_semantics_SUITE).
+-author("Vitor Enes Duarte <vitorenesduarte@gmail.com>").
+
+%% common_test callbacks
+-export([init_per_suite/1,
+         end_per_suite/1,
+         init_per_testcase/2,
+         end_per_testcase/2,
+         all/0]).
+
+%% tests
+-compile([export_all]).
+
+-include("state_type.hrl").
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% ===================================================================
+%% common_test callbacks
+%% ===================================================================
+
+init_per_suite(Config) -> Config.
+end_per_suite(Config) -> Config.
+init_per_testcase(_Case, Config) -> Config.
+end_per_testcase(_Case, Config) -> Config.
+
+all() ->
+    [
+        flag_test
+    ].
+
+%% ===================================================================
+%% tests
+%% ===================================================================
+
+flag_test(_Config) ->
+    List = [
+        {state_ewflag, true}
+    ],
+
+    lists:foreach(
+        fun({FlagType, ExpectedValue}) ->
+            {Value1, Value2} = flag_mutate_concurrently(FlagType),
+            ?assert(Value1 == Value2),
+            ?assertEqual(ExpectedValue, Value1)
+        end,
+        List
+    ).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+flag_mutate_concurrently(FlagType) ->
+    ActorA = "A",
+    ActorB = "B",
+    ActorC = "C",
+    Flag0 = FlagType:new(),
+    {ok, EFlag} = FlagType:mutate(enable, ActorC, Flag0),
+    {ok, DFlag} = FlagType:mutate(disable, ActorC, Flag0),
+
+    %% concurrent mutations in enabled flag
+    {ok, EFlagA} = FlagType:mutate(enable, ActorA, EFlag),
+    {ok, EFlagB} = FlagType:mutate(disable, ActorB, EFlag),
+    %% merge them
+    EFlagMerged = FlagType:merge(EFlagA, EFlagB),
+
+    %% concurrent mutations in disabled flag
+    {ok, DFlagA} = FlagType:mutate(enable, ActorA, DFlag),
+    {ok, DFlagB} = FlagType:mutate(disable, ActorB, DFlag),
+    %% merge them
+    DFlagMerged = FlagType:merge(DFlagA, DFlagB),
+
+    %% return query values
+    {
+        FlagType:query(EFlagMerged),
+        FlagType:query(DFlagMerged)
+    }.

--- a/test/state_type_semantics_SUITE.erl
+++ b/test/state_type_semantics_SUITE.erl
@@ -80,16 +80,22 @@ flag_mutate_concurrently(FlagType) ->
     Flag0 = FlagType:new(),
     {ok, EFlag} = FlagType:mutate(enable, ActorC, Flag0),
     {ok, DFlag} = FlagType:mutate(disable, ActorC, Flag0),
+    ?assertEqual(true, FlagType:query(EFlag)),
+    ?assertEqual(false, FlagType:query(DFlag)),
 
     %% concurrent mutations in enabled flag
     {ok, EFlagA} = FlagType:mutate(enable, ActorA, EFlag),
     {ok, EFlagB} = FlagType:mutate(disable, ActorB, EFlag),
+    ?assertEqual(true, FlagType:query(EFlagA)),
+    ?assertEqual(false, FlagType:query(EFlagB)),
     %% merge them
     EFlagMerged = FlagType:merge(EFlagA, EFlagB),
 
     %% concurrent mutations in disabled flag
     {ok, DFlagA} = FlagType:mutate(enable, ActorA, DFlag),
     {ok, DFlagB} = FlagType:mutate(disable, ActorB, DFlag),
+    ?assertEqual(true, FlagType:query(DFlagA)),
+    ?assertEqual(false, FlagType:query(DFlagB)),
     %% merge them
     DFlagMerged = FlagType:merge(DFlagA, DFlagB),
 


### PR DESCRIPTION
New Data Types:
- [x] LWWRegister #55 (timestamps are assumed globally unique and consistent with causal order)
- [x] MVRegister #56
- [x] DWFlag #57
- [x] EWFlag #58
- [x] ORMap #59

Others:
- [x] Refactor `state_causal_type.erl` into:
  - [x] DotStore
  - [x] DotSet
  - [x] DotFun
  - [x] DotMap
  - [x] CausalContext
- [x] Change `state_gmap` API (this will break Lasp, PR needed)
- [x] Add new test suite for flag semantics
- [x] Unified API for Registers #61 
