### PR TITLE
Support arbitrary CRDTs as GMap values

### DIFF
--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -54,7 +54,8 @@
 -type payload() :: {ctype(), orddict:orddict()}.
 -type key() :: term().
 -type key_op() :: term().
--type state_gmap_op() :: {apply, key(), key_op()}.
+-type state_gmap_op() :: {apply, key(), key_op()} |
+                         {apply, state_type:state_type(), key(), key_op()}.
 
 %% @doc Create a new, empty `state_gmap()'.
 %%      By default the values are a MaxInt CRDT.
@@ -80,11 +81,17 @@ mutate(Op, Actor, {?TYPE, _}=CRDT) ->
 %%      key.
 -spec delta_mutate(state_gmap_op(), type:id(), state_gmap()) ->
     {ok, state_gmap()}.
-delta_mutate({apply, Key, Op}, Actor, {?TYPE, {CType, GMap}}) ->
-    {Type, Args} = state_type:extract_args(CType),
-    {_, Default} = Type:new(Args),
-    Current = orddict_ext:fetch(Key, GMap, Default),
-    {ok, {Type, KeyDelta}} = Type:delta_mutate(Op, Actor, {Type, Current}),
+delta_mutate({apply, Key, Op}, Actor, {?TYPE, {CType, _}}=CRDT) ->
+    apply(CType, Key, Op, Actor, CRDT);
+delta_mutate({apply, OpType, Key, Op}, Actor, {?TYPE, {_CType, _}}=CRDT) ->
+    apply(OpType, Key, Op, Actor, CRDT).
+
+%% @private
+apply(OpType, Key, Op, Actor, {?TYPE, {CType, GMap}}) ->
+    {Type, Args} = state_type:extract_args(OpType),
+    Bottom = Type:new(Args),
+    Current = orddict_ext:fetch(Key, GMap, Bottom),
+    {ok, KeyDelta} = Type:delta_mutate(Op, Actor, Current),
     Delta = orddict:store(Key, KeyDelta, orddict:new()),
     {ok, {?TYPE, {CType, Delta}}}.
 
@@ -92,11 +99,10 @@ delta_mutate({apply, Key, Op}, Actor, {?TYPE, {CType, GMap}}) ->
 %%      This value is a dictionary where each key maps to the
 %%      result of `query/1' over the current value.
 -spec query(state_gmap()) -> term().
-query({?TYPE, {CType, GMap}}) ->
-    {Type, _Args} = state_type:extract_args(CType),
+query({?TYPE, {_, GMap}}) ->
     lists:map(
-        fun({Key, Value}) ->
-            {Key, Type:query({Type, Value})}
+        fun({Key, {Type, _}=CRDT}) ->
+            {Key, Type:query(CRDT)}
         end,
         GMap
     ).
@@ -110,12 +116,9 @@ query({?TYPE, {CType, GMap}}) ->
 %%      will be the `merge/2' of both values.
 -spec merge(state_gmap(), state_gmap()) -> state_gmap().
 merge({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
-    {Type, _Args} = state_type:extract_args(CType),
     GMap = orddict:merge(
-        fun(_, Value1, Value2) ->
-            {Type, Value} = Type:merge({Type, Value1},
-                                       {Type, Value2}),
-            Value
+        fun(_, {Type, _}=CRDT1, {Type, _}=CRDT2) ->
+            Type:merge(CRDT1, CRDT2)
         end,
         GMap1,
         GMap2
@@ -127,9 +130,8 @@ merge({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
 %%      and for each key, their values are also `equal/2'.
 -spec equal(state_gmap(), state_gmap()) -> boolean().
 equal({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
-    {Type, _Args} = state_type:extract_args(CType),
-    Fun = fun(Value1, Value2) ->
-        Type:equal({Type, Value1}, {Type, Value2})
+    Fun = fun({Type, _}=CRDT1, {Type, _}=CRDT2) ->
+        Type:equal(CRDT1, CRDT2)
     end,
     orddict_ext:equal(GMap1, GMap2, Fun).
 
@@ -148,12 +150,11 @@ is_bottom({?TYPE, {_CType, GMap}}) ->
 %%          should be an inflation of the value in the first.
 -spec is_inflation(state_gmap(), state_gmap()) -> boolean().
 is_inflation({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
-    {Type, _Args} = state_type:extract_args(CType),
     lists_ext:iterate_until(
-        fun({Key, Value1}) ->
+        fun({Key, {Type, _}=CRDT1}) ->
             case orddict:find(Key, GMap2) of
-                {ok, Value2} ->
-                    Type:is_inflation({Type, Value1}, {Type, Value2});
+                {ok, CRDT2} ->
+                    Type:is_inflation(CRDT1, CRDT2);
                 error ->
                     false
             end
@@ -208,8 +209,8 @@ new_test() ->
     ?assertEqual({?TYPE, {?GCOUNTER_TYPE, []}}, new([?GCOUNTER_TYPE])).
 
 query_test() ->
-    Counter1 = [{1, 1}, {2, 13}, {3, 1}],
-    Counter2 = [{2, 2}, {3, 13}, {5, 2}],
+    Counter1 = {?GCOUNTER_TYPE, [{1, 1}, {2, 13}, {3, 1}]},
+    Counter2 = {?GCOUNTER_TYPE, [{2, 2}, {3, 13}, {5, 2}]},
     Map0 = new([?GCOUNTER_TYPE]),
     Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, Counter1}, {<<"key2">>, Counter2}]}},
     ?assertEqual([], query(Map0)),
@@ -223,54 +224,42 @@ delta_apply_test() ->
     Map2 = merge({?TYPE, Delta2}, Map1),
     {ok, {?TYPE, Delta3}} = delta_mutate({apply, <<"key2">>, increment}, 1, Map2),
     Map3 = merge({?TYPE, Delta3}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}}, {?TYPE, Delta1}),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}}, Map1),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{2, 1}]}]}}, {?TYPE, Delta2}),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}, {2, 1}]}]}}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, [{1, 1}]}]}}, {?TYPE, Delta3}),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}, {2, 1}]},
-                                           {<<"key2">>, [{1, 1}]}]}}, Map3).
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map1),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{2, 1}]}}]}}, {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}}]}}, Map2),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, {?TYPE, Delta3}),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
+                                           {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map3).
 
 apply_test() ->
     Map0 = new([?GCOUNTER_TYPE]),
     {ok, Map1} = mutate({apply, <<"key1">>, increment}, 1, Map0),
     {ok, Map2} = mutate({apply, <<"key1">>, increment}, 2, Map1),
     {ok, Map3} = mutate({apply, <<"key2">>, increment}, 1, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}}, Map1),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}, {2, 1}]}]}}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}, {2, 1}]},
-                                           {<<"key2">>, [{1, 1}]}]}}, Map3).
-
-merge_deltas_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}},
-    Delta1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 17}]}]}},
-    Delta2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, [{1, 17}]}]}},
-    Map2 = merge(Delta1, Map1),
-    Map3 = merge(Map1, Delta1),
-    DeltaGroup = merge(Delta1, Delta2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 17}]}]}}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 17}]}]}}, Map3),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 17}]},
-                                           {<<"key2">>, [{1, 17}]}]}}, DeltaGroup).
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map1),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}}]}}, Map2),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
+                                           {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map3).
 
 equal_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}},
-    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 2}]}]}},
-    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, [{1, 1}]}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
+    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     ?assert(equal(Map1, Map1)),
     ?assertNot(equal(Map1, Map2)),
     ?assertNot(equal(Map1, Map3)).
 
 is_bottom_test() ->
     Map0 = new(),
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     ?assert(is_bottom(Map0)),
     ?assertNot(is_bottom(Map1)).
 
 is_inflation_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}},
-    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 2}]}]}},
-    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, [{1, 1}]}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
+    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     ?assert(is_inflation(Map1, Map1)),
     ?assert(is_inflation(Map1, Map2)),
     ?assertNot(is_inflation(Map1, Map3)),
@@ -280,9 +269,9 @@ is_inflation_test() ->
     ?assertNot(state_type:is_inflation(Map1, Map3)).
 
 is_strict_inflation_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}},
-    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 2}]}]}},
-    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, [{1, 1}]}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
+    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     ?assertNot(is_strict_inflation(Map1, Map1)),
     ?assert(is_strict_inflation(Map1, Map2)),
     ?assertNot(is_strict_inflation(Map1, Map3)).
@@ -292,7 +281,7 @@ join_decomposition_test() ->
     ok.
 
 encode_decode_test() ->
-    Map = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, [{1, 1}]}]}},
+    Map = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
     Binary = encode(erlang, Map),
     EMap = decode(erlang, Binary),
     ?assertEqual(Map, EMap).

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -30,7 +30,7 @@
          all/0]).
 
 %% tests
--compile([export_all]).
+-compile([nowarn_export_all, export_all]).
 
 -include("state_type.hrl").
 
@@ -269,8 +269,8 @@ pair_with_gcounter_and_gmap_test(_Config) ->
 
     ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, []}, {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}}}, Pair0),
     ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}}}, Pair1),
-    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}}}, Pair2),
-    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 2}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}}}, Pair3),
+    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}}}, Pair2),
+    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 2}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}}}, Pair3),
     ?assertEqual({2, [{Actor, true}]}, Query).
 
 pair_with_gmap_and_pair_with_gcounter_and_gmap_test(_Config) ->
@@ -295,24 +295,24 @@ pair_with_gmap_and_pair_with_gcounter_and_gmap_test(_Config) ->
         }}
     }}, Pair0),
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, []},
             {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
         }}
     }}, Pair1),
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
             {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
         }}
     }}, Pair2),
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
         }}
     }}, Pair3),
     ?assertEqual({
@@ -346,21 +346,21 @@ pair_with_pair_with_gcounter_and_gmap_and_gmap_test(_Config) ->
             {?GCOUNTER_TYPE, []},
             {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
     }}, Pair1),
     ?assertEqual({?PAIR_TYPE, {
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
             {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
     }}, Pair2),
     ?assertEqual({?PAIR_TYPE, {
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, 1}]}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
     }}, Pair3),
     ?assertEqual({
         {1, [{Actor, true}]},
@@ -377,9 +377,9 @@ gmap_with_pair_test(_Config) ->
     Query = ?GMAP_TYPE:query(GMap3),
 
     ?assertEqual({?GMAP_TYPE, {CType, []}}, GMap0),
-    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 0}}}]}}, GMap1),
-    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {{?BOOLEAN_TYPE, 0}, {?BOOLEAN_TYPE, 1}}}]}}, GMap2),
-    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 1}}}]}}, GMap3),
+    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 0}}}}]}}, GMap1),
+    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 0}, {?BOOLEAN_TYPE, 1}}}}]}}, GMap2),
+    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 1}}}}]}}, GMap3),
     ?assertEqual([{Actor, {true, true}}], Query).
 
 maps_within_maps_test(_Config) ->

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -421,16 +421,24 @@ awmap_nested_rmv_test(_Config) ->
 gmap_with_arbitrary_nested_values_test(_Config) ->
     Actor = "A",
     Map0 = ?GMAP_TYPE:new([?LWWREGISTER_TYPE]),
-    {ok, Map1} = ?GMAP_TYPE:mutate({apply, {?GMAP_TYPE, [?AWSET_TYPE]}, "set", {apply, "key", {add, 3}}}, Actor, Map0),
-    {ok, Map2} = ?GMAP_TYPE:mutate({apply, ?LWWREGISTER_TYPE, "reg", {set, 1, "hello"}}, Actor, Map1),
+    {ok, Map1} = ?GMAP_TYPE:mutate({apply, "set", {?GMAP_TYPE, [?AWSET_TYPE]}, {apply, "key", {add, 3}}}, Actor, Map0),
+    {ok, Map2} = ?GMAP_TYPE:mutate({apply, "reg", ?LWWREGISTER_TYPE, {set, 1, "hello"}}, Actor, Map1),
     {ok, Map3} = ?GMAP_TYPE:mutate({apply, "reg", {set, 2, "world"}}, Actor, Map2),
+
     Query1 = ?GMAP_TYPE:query(Map1),
     Query2 = ?GMAP_TYPE:query(Map2),
     Query3 = ?GMAP_TYPE:query(Map3),
 
     ?assertEqual([{"set", [{"key", sets:from_list([3])}]}], Query1),
     ?assertEqual([{"reg", "hello"}, {"set", [{"key", sets:from_list([3])}]}], Query2),
-    ?assertEqual([{"reg", "world"}, {"set", [{"key", sets:from_list([3])}]}], Query3).
+    ?assertEqual([{"reg", "world"}, {"set", [{"key", sets:from_list([3])}]}], Query3),
+
+    {ok, Map4} = ?GMAP_TYPE:mutate({apply_all, [{"set", {?GMAP_TYPE, [?AWSET_TYPE]}, {apply, "key", {add, 3}}},
+                                                {"reg", ?LWWREGISTER_TYPE, {set, 1, "hello"}},
+                                                {"reg", {set, 2, "world"}}]}, Actor, Map0),
+
+    ?assert(?GMAP_TYPE:equal(Map3, Map4)).
+
 
 %% ===================================================================
 %% Internal functions

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -58,7 +58,8 @@ all() ->
         pair_with_pair_with_gcounter_and_gmap_and_gmap_test,
         gmap_with_pair_test,
         maps_within_maps_test,
-        awmap_nested_rmv_test
+        awmap_nested_rmv_test,
+        gmap_with_arbitrary_nested_values_test
     ].
 
 %% ===================================================================
@@ -416,6 +417,20 @@ awmap_nested_rmv_test(_Config) ->
     ?assertEqual([{"hello", [{"world_two", sets:from_list([7])}, {"world_z", sets:from_list([23])}]}], Query6),
     ?assertEqual([{"hello", [{"world_z", sets:from_list([23])}]}], Query7),
     ?assertEqual([], Query8).
+
+gmap_with_arbitrary_nested_values_test(_Config) ->
+    Actor = "A",
+    Map0 = ?GMAP_TYPE:new([?LWWREGISTER_TYPE]),
+    {ok, Map1} = ?GMAP_TYPE:mutate({apply, {?GMAP_TYPE, [?AWSET_TYPE]}, "set", {apply, "key", {add, 3}}}, Actor, Map0),
+    {ok, Map2} = ?GMAP_TYPE:mutate({apply, ?LWWREGISTER_TYPE, "reg", {set, 1, "hello"}}, Actor, Map1),
+    {ok, Map3} = ?GMAP_TYPE:mutate({apply, "reg", {set, 2, "world"}}, Actor, Map2),
+    Query1 = ?GMAP_TYPE:query(Map1),
+    Query2 = ?GMAP_TYPE:query(Map2),
+    Query3 = ?GMAP_TYPE:query(Map3),
+
+    ?assertEqual([{"set", [{"key", sets:from_list([3])}]}], Query1),
+    ?assertEqual([{"reg", "hello"}, {"set", [{"key", sets:from_list([3])}]}], Query2),
+    ?assertEqual([{"reg", "world"}, {"set", [{"key", sets:from_list([3])}]}], Query3).
 
 %% ===================================================================
 %% Internal functions

--- a/test/state_type_semantics_SUITE.erl
+++ b/test/state_type_semantics_SUITE.erl
@@ -30,7 +30,7 @@
          all/0]).
 
 %% tests
--compile([export_all]).
+-compile([nowarn_export_all, export_all]).
 
 -include("state_type.hrl").
 


### PR DESCRIPTION
(Targeting #83)

Until now, it was assumed that all values within a map had the same CRDT type.