### PR TITLE
 Add GMap join-decomposition recursive definition

### DIFF
--- a/src/dict_ext.erl
+++ b/src/dict_ext.erl
@@ -1,0 +1,32 @@
+%%
+%% Copyright (c) 2018 Christopher Meiklejohn.  All Rights Reserved.
+%%
+%% This file is provided to you under the Apache License,
+%% Version 2.0 (the "License"); you may not use this file
+%% except in compliance with the License.  You may obtain
+%% a copy of the License at
+%%
+%%   http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing,
+%% software distributed under the License is distributed on an
+%% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+%% KIND, either express or implied.  See the License for the
+%% specific language governing permissions and limitations
+%% under the License.
+%%
+%% -------------------------------------------------------------------
+
+-module(dict_ext).
+-author("Vitor Enes <vitorenesduarte@gmail.com>").
+
+-export([fetch/3]).
+
+%% @doc
+fetch(K, M, Default) ->
+    case dict:find(K, M) of
+        {ok, V} ->
+            V;
+        error ->
+            Default
+    end.

--- a/src/state_bcounter.erl
+++ b/src/state_bcounter.erl
@@ -1,3 +1,4 @@
+
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
 %%
@@ -90,8 +91,8 @@ delta_mutate({move, Count, To}, Actor, {?TYPE, {PNCounter, GMap}}=BCounter) ->
     {?GMAP_TYPE, {?MAX_INT_TYPE, Map0}} = GMap,
     case Count =< permissions(BCounter, Actor) of
         true ->
-            Current = orddict_ext:fetch({Actor, To}, Map0, 0),
-            Map1 = orddict:store({Actor, To}, Current + Count, orddict:new()),
+            Current = dict_ext:fetch({Actor, To}, Map0, 0),
+            Map1 = dict:store({Actor, To}, Current + Count, dict:new()),
             Delta = {state_type:new(PNCounter), {?GMAP_TYPE, {?MAX_INT_TYPE, Map1}}},
             {ok, {?TYPE, Delta}};
         false ->
@@ -122,7 +123,7 @@ permissions({?TYPE, {{?PNCOUNTER_TYPE, PNCounter},
                      {?GMAP_TYPE, {?MAX_INT_TYPE, GMap}}}}, Actor) ->
     {Inc, Dec} = orddict_ext:fetch(Actor, PNCounter, {0, 0}),
     Local = Inc - Dec,
-    {Incoming, Outgoing} = orddict:fold(
+    {Incoming, Outgoing} = dict:fold(
         fun({From, To}, Value, {In0, Out0}) ->
             In1 = case To == Actor of
                 true ->
@@ -244,7 +245,8 @@ new_test() ->
 
 query_test() ->
     BCounter0 = new(),
-    BCounter1 = {?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {5, 0}}, {3, {10, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}},
+    BCounter1 = {?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {5, 0}}, {3, {10, 0}}]},
+                         {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}},
     ?assertEqual(0, query(BCounter0)),
     ?assertEqual(17, query(BCounter1)).
 
@@ -256,21 +258,30 @@ delta_increment_test() ->
     BCounter2 = merge({?TYPE, Delta2}, BCounter1),
     {ok, {?TYPE, Delta3}} = delta_mutate(increment, 2, BCounter2),
     BCounter3 = merge({?TYPE, Delta3}, BCounter2),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {1, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, {?TYPE, Delta1}),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {1, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter1),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, {?TYPE, Delta2}),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter2),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{2, {1, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, {?TYPE, Delta3}),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {1, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter3).
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {1, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {1, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter1),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter2),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{2, {1, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, {?TYPE, Delta3}),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {1, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter3).
 
 add_test() ->
     BCounter0 = new(),
     {ok, BCounter1} = mutate(increment, 1, BCounter0),
     {ok, BCounter2} = mutate(increment, 1, BCounter1),
     {ok, BCounter3} = mutate(increment, 2, BCounter2),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {1, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter1),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter2),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {1, 0}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter3).
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {1, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter1),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter2),
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {1, 0}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter3).
 
 delta_decrement_test() ->
     Actor = 1,
@@ -280,7 +291,8 @@ delta_decrement_test() ->
     {ok, {?TYPE, Delta1}} = delta_mutate(decrement, Actor, BCounter1),
     BCounter2 = merge({?TYPE, Delta1}, BCounter1),
     {error, _} = delta_mutate(decrement, Actor, BCounter2),
-    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{Actor, {1, 1}}]}, {?GMAP_TYPE, {?MAX_INT_TYPE, []}}}}, BCounter2).
+    ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{Actor, {1, 1}}]},
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}}}}, BCounter2).
 
 delta_move_test() ->
     From = 1,
@@ -303,12 +315,13 @@ delta_move_test() ->
     {ok, {?TYPE, Delta4}} = delta_mutate(decrement, From, BCounter5),
     BCounter6 = merge({?TYPE, Delta4}, BCounter5),
     ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{From, {2, 0}}]},
-                          {?GMAP_TYPE, {?MAX_INT_TYPE, [{{From, To}, 2}]}}}}, BCounter3),
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([{{From, To}, 2}])}}}}, BCounter3),
     ?assertEqual({?TYPE, {{?PNCOUNTER_TYPE, [{From, {2, 1}}, {To, {0, 1}}]},
-                          {?GMAP_TYPE, {?MAX_INT_TYPE, [{{From, To}, 2}, {{To, From}, 1}]}}}}, BCounter6).
+                          {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([{{From, To}, 2},
+                                                                       {{To, From}, 1}])}}}}, BCounter6).
 
 merge_deltas_test() ->
-    GMap = {?GMAP_TYPE, {?MAX_INT_TYPE, []}},
+    GMap = {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}},
     BCounter1 = {?TYPE, {{?PNCOUNTER_TYPE, [{1, {2, 0}}, {2, {1, 0}}]}, GMap}},
     Delta1 = {?TYPE, {{?PNCOUNTER_TYPE, [{1, {4, 0}}]}, GMap}},
     Delta2 = {?TYPE, {{?PNCOUNTER_TYPE, [{2, {1, 17}}]}, GMap}},
@@ -324,7 +337,7 @@ join_decomposition_test() ->
     ok.
 
 encode_decode_test() ->
-    GMap = {?GMAP_TYPE, {?MAX_INT_TYPE, []}},
+    GMap = {?GMAP_TYPE, {?MAX_INT_TYPE, dict:from_list([])}},
     Counter = {?TYPE, {{?PNCOUNTER_TYPE, [{1, {4, 0}}, {2, {1, 0}}]}, GMap}},
     Binary = encode(erlang, Counter),
     ECounter = decode(erlang, Binary),

--- a/src/state_bcounter.erl
+++ b/src/state_bcounter.erl
@@ -1,4 +1,3 @@
-
 %%
 %% Copyright (c) 2015-2016 Christopher Meiklejohn.  All Rights Reserved.
 %%

--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -172,8 +172,17 @@ is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
 -spec irreducible_is_strict_inflation(state_gmap(),
                                       state_type:digest()) ->
     boolean().
-irreducible_is_strict_inflation({?TYPE, _}=A, B) ->
-    state_type:irreducible_is_strict_inflation(A, B).
+irreducible_is_strict_inflation({?TYPE, {_CType, GMap1}},
+                                {state, {?TYPE, {_CType, GMap2}}}) ->
+    [{Key, {Type, _}=V1}] = dict:to_list(GMap1),
+    case dict:find(Key, GMap2) of
+        error ->
+            %% it will inflate if it's not a key in the other map
+            true;
+        {ok, {Type, _}=V2} ->
+            %% if it's present, recursive call
+            Type:irreducible_is_strict_inflation(V1, {state, V2})
+    end.
 
 -spec digest(state_gmap()) -> state_type:digest().
 digest({?TYPE, _}=CRDT) ->

--- a/src/state_gmap.erl
+++ b/src/state_gmap.erl
@@ -51,7 +51,7 @@
 
 -opaque state_gmap() :: {?TYPE, payload()}.
 -type ctype() :: state_type:state_type() | {state_type:state_type(), [term()]}.
--type payload() :: {ctype(), orddict:orddict()}.
+-type payload() :: {ctype(), dict:dict()}.
 -type key() :: term().
 -type key_op() :: term().
 -type op() :: {key(), key_op()} | {key(), ctype(), key_op()}.
@@ -68,7 +68,7 @@ new() ->
 %% @doc Create a new, empty `state_gmap()'
 -spec new([term()]) -> state_gmap().
 new([CType]) ->
-    {?TYPE, {CType, orddict:new()}}.
+    {?TYPE, {CType, dict:new()}}.
 
 %% @doc Mutate a `state_gmap()'.
 -spec mutate(state_gmap_op(), type:id(), state_gmap()) ->
@@ -104,10 +104,10 @@ apply_op({Key, Op}, Actor, {?TYPE, {CType, _}}=CRDT) ->
 apply_op({Key, OpType, Op}, Actor, {?TYPE, {CType, GMap}}) ->
     {Type, Args} = state_type:extract_args(OpType),
     Bottom = Type:new(Args),
-    Current = orddict_ext:fetch(Key, GMap, Bottom),
+    Current = dict_ext:fetch(Key, GMap, Bottom),
     {ok, KeyDelta} = Type:delta_mutate(Op, Actor, Current),
-    % orddict:store(Key, KeyDelta, orddict:new()),
-    Delta = [{Key, KeyDelta}],
+    % dict:store(Key, KeyDelta, dict:new()),
+    Delta = dict:from_list([{Key, KeyDelta}]),
     {?TYPE, {CType, Delta}}.
 
 %% @doc Returns the value of the `state_gmap()'.
@@ -115,10 +115,11 @@ apply_op({Key, OpType, Op}, Actor, {?TYPE, {CType, GMap}}) ->
 %%      result of `query/1' over the current value.
 -spec query(state_gmap()) -> term().
 query({?TYPE, {_, GMap}}) ->
-    lists:map(
-        fun({Key, {Type, _}=CRDT}) ->
-            {Key, Type:query(CRDT)}
+    dict:fold(
+        fun(Key, {Type, _}=CRDT, Acc) ->
+            [{Key, Type:query(CRDT)} | Acc]
         end,
+        [],
         GMap
     ).
 
@@ -131,7 +132,7 @@ query({?TYPE, {_, GMap}}) ->
 %%      will be the `merge/2' of both values.
 -spec merge(state_gmap(), state_gmap()) -> state_gmap().
 merge({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
-    GMap = orddict:merge(
+    GMap = dict:merge(
         fun(_, {Type, _}=CRDT1, {Type, _}=CRDT2) ->
             Type:merge(CRDT1, CRDT2)
         end,
@@ -141,19 +142,14 @@ merge({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
     {?TYPE, {CType, GMap}}.
 
 %% @doc Equality for `state_gmap()'.
-%%      Two `state_gmap()' are equal if they have the same keys
-%%      and for each key, their values are also `equal/2'.
 -spec equal(state_gmap(), state_gmap()) -> boolean().
 equal({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
-    Fun = fun({Type, _}=CRDT1, {Type, _}=CRDT2) ->
-        Type:equal(CRDT1, CRDT2)
-    end,
-    orddict_ext:equal(GMap1, GMap2, Fun).
+    dict:to_list(GMap1) == dict:to_list(GMap2).
 
 %% @doc Check if a `state_gmap()' is bottom
 -spec is_bottom(state_gmap()) -> boolean().
 is_bottom({?TYPE, {_CType, GMap}}) ->
-    orddict:is_empty(GMap).
+    dict:is_empty(GMap).
 
 %% @doc Given two `state_gmap()', check if the second is an inflation
 %%      of the first.
@@ -164,18 +160,8 @@ is_bottom({?TYPE, {_CType, GMap}}) ->
 %%          the correspondent value in the second `state_gmap()'
 %%          should be an inflation of the value in the first.
 -spec is_inflation(state_gmap(), state_gmap()) -> boolean().
-is_inflation({?TYPE, {CType, GMap1}}, {?TYPE, {CType, GMap2}}) ->
-    lists_ext:iterate_until(
-        fun({Key, {Type, _}=CRDT1}) ->
-            case orddict:find(Key, GMap2) of
-                {ok, CRDT2} ->
-                    Type:is_inflation(CRDT1, CRDT2);
-                error ->
-                    false
-            end
-        end,
-        GMap1
-     ).
+is_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
+    state_type:is_inflation(CRDT1, CRDT2).
 
 %% @doc Check for strict inflation.
 -spec is_strict_inflation(state_gmap(), state_gmap()) -> boolean().
@@ -197,11 +183,11 @@ digest({?TYPE, _}=CRDT) ->
 %% @todo
 -spec join_decomposition(state_gmap()) -> [state_gmap()].
 join_decomposition({?TYPE, {CType, GMap}}) ->
-    lists:foldl(
-        fun({Key, {Type, _}=CRDT}, Acc0) ->
+    dict:fold(
+        fun(Key, {Type, _}=CRDT, Acc0) ->
             lists:foldl(
                 fun(NestedIrreducible, Acc1) ->
-                    Irreducible = {?TYPE, {CType, [{Key, NestedIrreducible}]}},
+                    Irreducible = {?TYPE, {CType, dict:from_list([{Key, NestedIrreducible}])}},
                     [Irreducible | Acc1]
                 end,
                 Acc0,
@@ -233,16 +219,17 @@ decode(erlang, Binary) ->
 -ifdef(TEST).
 
 new_test() ->
-    ?assertEqual({?TYPE, {?MAX_INT_TYPE, []}}, new()),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, []}}, new([?GCOUNTER_TYPE])).
+    ?assertEqual({?TYPE, {?MAX_INT_TYPE, dict:from_list([])}}, new()),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, dict:from_list([])}}, new([?GCOUNTER_TYPE])).
 
 query_test() ->
     Counter1 = {?GCOUNTER_TYPE, [{1, 1}, {2, 13}, {3, 1}]},
     Counter2 = {?GCOUNTER_TYPE, [{2, 2}, {3, 13}, {5, 2}]},
     Map0 = new([?GCOUNTER_TYPE]),
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, Counter1}, {<<"key2">>, Counter2}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE, dict:from_list([{<<"key1">>, Counter1},
+                                                    {<<"key2">>, Counter2}])}},
     ?assertEqual([], query(Map0)),
-    ?assertEqual([{<<"key1">>, 15}, {<<"key2">>, 17}], query(Map1)).
+    ?assertEqual([{<<"key1">>, 15}, {<<"key2">>, 17}], lists:sort(query(Map1))).
 
 delta_apply_test() ->
     Map0 = new([?GCOUNTER_TYPE]),
@@ -252,42 +239,58 @@ delta_apply_test() ->
     Map2 = merge({?TYPE, Delta2}, Map1),
     {ok, {?TYPE, Delta3}} = delta_mutate({apply, <<"key2">>, increment}, 1, Map2),
     Map3 = merge({?TYPE, Delta3}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, {?TYPE, Delta1}),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map1),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{2, 1}]}}]}}, {?TYPE, Delta2}),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}}]}}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, {?TYPE, Delta3}),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
-                                           {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map3).
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}}, {?TYPE, Delta1}),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}}, Map1),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{2, 1}]}}])}}, {?TYPE, Delta2}),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}}])}}, Map2),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}}, {?TYPE, Delta3}),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
+                                          {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}}, Map3).
 
 apply_test() ->
     Map0 = new([?GCOUNTER_TYPE]),
     {ok, Map1} = mutate({apply, <<"key1">>, increment}, 1, Map0),
     {ok, Map2} = mutate({apply, <<"key1">>, increment}, 2, Map1),
     {ok, Map3} = mutate({apply, <<"key2">>, increment}, 1, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map1),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}}]}}, Map2),
-    ?assertEqual({?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
-                                           {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}}, Map3).
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}}, Map1),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}}])}}, Map2),
+    ?assertEqual({?TYPE, {?GCOUNTER_TYPE,
+                          dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}, {2, 1}]}},
+                                          {<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}}, Map3).
 
 equal_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
-    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
-    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
+    Map2 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}])}},
+    Map3 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
     ?assert(equal(Map1, Map1)),
     ?assertNot(equal(Map1, Map2)),
     ?assertNot(equal(Map1, Map3)).
 
 is_bottom_test() ->
     Map0 = new(),
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
     ?assert(is_bottom(Map0)),
     ?assertNot(is_bottom(Map1)).
 
 is_inflation_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
-    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
-    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
+    Map2 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}])}},
+    Map3 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
     ?assert(is_inflation(Map1, Map1)),
     ?assert(is_inflation(Map1, Map2)),
     ?assertNot(is_inflation(Map1, Map3)),
@@ -297,9 +300,12 @@ is_inflation_test() ->
     ?assertNot(state_type:is_inflation(Map1, Map3)).
 
 is_strict_inflation_test() ->
-    Map1 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
-    Map2 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}]}},
-    Map3 = {?TYPE, {?GCOUNTER_TYPE, [{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map1 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
+    Map2 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 2}]}}])}},
+    Map3 = {?TYPE, {?GCOUNTER_TYPE,
+                    dict:from_list([{<<"key2">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
     ?assertNot(is_strict_inflation(Map1, Map1)),
     ?assert(is_strict_inflation(Map1, Map2)),
     ?assertNot(is_strict_inflation(Map1, Map3)).
@@ -311,14 +317,18 @@ join_decomposition_test() ->
     {ok, Map3} = mutate({apply, key2, {set, 12, b}}, undefined, Map2),
     {ok, Map4} = mutate({apply, key3, {set, 13, c}}, undefined, Map3),
 
-    Expected = [{?TYPE, {?LWWREGISTER_TYPE, [{key1, {?LWWREGISTER_TYPE, {11, a}}}]}},
-                {?TYPE, {?LWWREGISTER_TYPE, [{key2, {?LWWREGISTER_TYPE, {12, b}}}]}},
-                {?TYPE, {?LWWREGISTER_TYPE, [{key3, {?LWWREGISTER_TYPE, {13, c}}}]}}],
+    Expected = [{?TYPE, {?LWWREGISTER_TYPE,
+                         dict:from_list([{key1, {?LWWREGISTER_TYPE, {11, a}}}])}},
+                {?TYPE, {?LWWREGISTER_TYPE,
+                         dict:from_list([{key2, {?LWWREGISTER_TYPE, {12, b}}}])}},
+                {?TYPE, {?LWWREGISTER_TYPE,
+                         dict:from_list([{key3, {?LWWREGISTER_TYPE, {13, c}}}])}}],
 
     ?assertEqual(lists:sort(Expected), lists:sort(join_decomposition(Map4))).
 
 encode_decode_test() ->
-    Map = {?TYPE, {?GCOUNTER_TYPE, [{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}]}},
+    Map = {?TYPE, {?GCOUNTER_TYPE,
+                   dict:from_list([{<<"key1">>, {?GCOUNTER_TYPE, [{1, 1}]}}])}},
     Binary = encode(erlang, Map),
     EMap = decode(erlang, Binary),
     ?assertEqual(Map, EMap).
@@ -330,7 +340,7 @@ equivalent_with_gcounter_test() ->
     {ok, Map1} = mutate({apply, Actor1, increment}, undefined, Map0),
     {ok, Map2} = mutate({apply, Actor1, increment}, undefined, Map1),
     {ok, Map3} = mutate({apply, Actor2, increment}, undefined, Map2),
-    [{Actor1, Value1}, {Actor2, Value2}] = query(Map3),
+    [{Actor1, Value1}, {Actor2, Value2}] = lists:sort(query(Map3)),
     GCounter0 = ?GCOUNTER_TYPE:new(),
     {ok, GCounter1} = ?GCOUNTER_TYPE:mutate(increment, Actor1, GCounter0),
     {ok, GCounter2} = ?GCOUNTER_TYPE:mutate(increment, Actor1, GCounter1),

--- a/src/state_lwwregister.erl
+++ b/src/state_lwwregister.erl
@@ -122,15 +122,15 @@ is_inflation({?TYPE, {Timestamp1, _}}, {?TYPE, {Timestamp2, _}}) ->
 
 %% @doc Check for strict inflation.
 -spec is_strict_inflation(state_lwwregister(), state_lwwregister()) -> boolean().
-is_strict_inflation({?TYPE, _}=CRDT1, {?TYPE, _}=CRDT2) ->
-    state_type:is_strict_inflation(CRDT1, CRDT2).
+is_strict_inflation({?TYPE, {Timestamp1, _}}, {?TYPE, {Timestamp2, _}}) ->
+    Timestamp2 > Timestamp1.
 
 %% @doc Check for irreducible strict inflation.
 -spec irreducible_is_strict_inflation(state_lwwregister(),
                                       state_type:digest()) ->
     boolean().
-irreducible_is_strict_inflation({?TYPE, _}=A, B) ->
-    state_type:irreducible_is_strict_inflation(A, B).
+irreducible_is_strict_inflation(A, B) ->
+    is_strict_inflation(A, B).
 
 -spec digest(state_lwwregister()) -> state_type:digest().
 digest({?TYPE, _}=CRDT) ->

--- a/src/state_lwwregister.erl
+++ b/src/state_lwwregister.erl
@@ -129,7 +129,7 @@ is_strict_inflation({?TYPE, {Timestamp1, _}}, {?TYPE, {Timestamp2, _}}) ->
 -spec irreducible_is_strict_inflation(state_lwwregister(),
                                       state_type:digest()) ->
     boolean().
-irreducible_is_strict_inflation(A, B) ->
+irreducible_is_strict_inflation(A, {state, B}) ->
     is_strict_inflation(A, B).
 
 -spec digest(state_lwwregister()) -> state_type:digest().

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -157,7 +157,11 @@ irreducible_is_strict_inflation({Type, _}=Irreducible,
 delta({decomposition, Decomp}, B) ->
     do_delta(Decomp, B);
 delta({Type, _}=A, B) ->
-    do_delta(Type:join_decomposition(A), B).
+    Decomp = Type:join_decomposition(A),
+    case Decomp of
+        [] -> new(A);
+        _ -> do_delta(Decomp, B)
+    end.
 
 %% @private
 do_delta([{Type, _}=H|_]=Decomp, B) ->

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -193,7 +193,9 @@ crdt_size({?AWSET_TYPE, {DotMap, CausalContext}}) ->
 crdt_size({?GCOUNTER_TYPE, CRDT}) ->
     {orddict:size(CRDT), 0};
 crdt_size({?GSET_TYPE, CRDT}) ->
-    {0, ordsets:size(CRDT)}.
+    {0, ordsets:size(CRDT)};
+crdt_size({?GMAP_TYPE, {_, CRDT}}) ->
+    {orddict:size(CRDT), 0}.
 
 %% @doc Digest size.
 digest_size({ActiveDots, CausalContext}) ->

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -178,6 +178,7 @@ extract_args(Type) ->
 %% @doc CRDT size.
 %%      First component is the metadata size,
 %%      the second component is the payload size.
+-spec crdt_size(crdt()) -> {non_neg_integer(), non_neg_integer()}.
 crdt_size({?AWSET_TYPE, {DotMap, CausalContext}}) ->
     %% size of the dot map
     {M, P} = dot_map:fold(

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -176,21 +176,23 @@ extract_args(Type) ->
     {Type, []}.
 
 %% @doc CRDT size.
+%%      First component is the metadata size,
+%%      the second component is the payload size.
 crdt_size({?AWSET_TYPE, {DotMap, CausalContext}}) ->
     %% size of the dot map
-    dot_map:fold(
-        fun(_, DotSet, Acc) ->
+    {M, P} = dot_map:fold(
+        fun(_, DotSet, {MAcc, PAcc}) ->
             %% size of the dot set, +1 for the key
-            Acc + dot_set_size(DotSet) + 1
+            {MAcc + dot_set_size(DotSet), PAcc + 1}
         end,
-        0,
+        {0, 0},
         DotMap
-    ) +
-    causal_context_size(CausalContext);
+    ),
+    {M + causal_context_size(CausalContext), P};
 crdt_size({?GCOUNTER_TYPE, CRDT}) ->
-    orddict:size(CRDT);
+    {orddict:size(CRDT), 0};
 crdt_size({?GSET_TYPE, CRDT}) ->
-    ordsets:size(CRDT).
+    {0, ordsets:size(CRDT)}.
 
 %% @doc Digest size.
 digest_size({ActiveDots, CausalContext}) ->

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -195,7 +195,7 @@ crdt_size({?GCOUNTER_TYPE, CRDT}) ->
 crdt_size({?GSET_TYPE, CRDT}) ->
     {0, ordsets:size(CRDT)};
 crdt_size({?GMAP_TYPE, {_, CRDT}}) ->
-    {orddict:size(CRDT), 0}.
+    {dict:size(CRDT), 0}.
 
 %% @doc Digest size.
 digest_size({ActiveDots, CausalContext}) ->

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -153,8 +153,14 @@ irreducible_is_strict_inflation({Type, _}=Irreducible,
     Type:is_strict_inflation(CRDT, Merged).
 
 %% @doc Generic delta calculation.
--spec delta(crdt(), digest()) -> crdt().
+-spec delta({decomposition, [crdt()]} | crdt(), digest()) -> crdt().
+delta({decomposition, Decomp}, B) ->
+    do_delta(Decomp, B);
 delta({Type, _}=A, B) ->
+    do_delta(Type:join_decomposition(A), B).
+
+%% @private
+do_delta([{Type, _}=H|_]=Decomp, B) ->
     lists:foldl(
         fun(Irreducible, Acc) ->
             case Type:irreducible_is_strict_inflation(Irreducible,
@@ -165,8 +171,8 @@ delta({Type, _}=A, B) ->
                     Acc
             end
         end,
-        new(A),
-        Type:join_decomposition(A)
+        new(H),
+        Decomp
     ).
 
 %% @doc extract arguments from complex (composite) types

--- a/src/state_type.erl
+++ b/src/state_type.erl
@@ -175,26 +175,15 @@ extract_args(Type) ->
     {Type, []}.
 
 %% @doc Term size.
-crdt_size({?AWMAP_TYPE, {_CType, CRDT}}) -> crdt_size(CRDT);
-crdt_size({?AWSET_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?BCOUNTER_TYPE, {CRDT1, CRDT2}}) ->
-    crdt_size(CRDT1) + crdt_size(CRDT2);
-crdt_size({?BOOLEAN_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?DWFLAG_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?EWFLAG_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?GCOUNTER_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?GMAP_TYPE, {_CType, CRDT}}) -> crdt_size(CRDT);
-crdt_size({?GSET_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?IVAR_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?LEXCOUNTER_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?LWWREGISTER_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?MAX_INT_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?MVMAP_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?MVREGISTER_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?ORSET_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?PAIR_TYPE, {CRDT1, CRDT2}}) ->
-    crdt_size(CRDT1) + crdt_size(CRDT2);
-crdt_size({?PNCOUNTER_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size({?TWOPSET_TYPE, CRDT}) -> crdt_size(CRDT);
-crdt_size(T) ->
-    erts_debug:flat_size(T).
+crdt_size({?AWSET_TYPE, {DotMap, {Compressed, DotSet}}}) ->
+    %% size of the dot map here is 2 times its size:
+    %% - 1 for the dot (assuming a single supporting dot)
+    %% - 1 for the element
+    %% size of the causal context is the number of entries
+    %% in the compressed component plus the number
+    %% of the dots in the non-compressed part
+    (2 * orddict:size(DotMap)) + orddict:size(Compressed) + ordsets:size(DotSet);
+crdt_size({?GCOUNTER_TYPE, CRDT}) ->
+    orddict:size(CRDT);
+crdt_size({?GSET_TYPE, CRDT}) ->
+    ordsets:size(CRDT).

--- a/test/state_type_composability_SUITE.erl
+++ b/test/state_type_composability_SUITE.erl
@@ -268,10 +268,14 @@ pair_with_gcounter_and_gmap_test(_Config) ->
     {ok, Pair3} = ?PAIR_TYPE:mutate({fst, increment}, Actor, Pair2),
     Query = ?PAIR_TYPE:query(Pair3),
 
-    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, []}, {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}}}, Pair0),
-    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}}}, Pair1),
-    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}}}, Pair2),
-    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 2}]}, {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}}}, Pair3),
+    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, []},
+                               {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}}}, Pair0),
+    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]},
+                               {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}}}, Pair1),
+    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 1}]},
+                               {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}}}, Pair2),
+    ?assertEqual({?PAIR_TYPE, {{?GCOUNTER_TYPE, [{Actor, 2}]},
+                               {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}}}, Pair3),
     ?assertEqual({2, [{Actor, true}]}, Query).
 
 pair_with_gmap_and_pair_with_gcounter_and_gmap_test(_Config) ->
@@ -289,31 +293,31 @@ pair_with_gmap_and_pair_with_gcounter_and_gmap_test(_Config) ->
     Query = ?PAIR_TYPE:query(Pair3),
 
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, []}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, []},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
         }}
     }}, Pair0),
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, []},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
         }}
     }}, Pair1),
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
         }}
     }}, Pair2),
     ?assertEqual({?PAIR_TYPE, {
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}},
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}},
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}
         }}
     }}, Pair3),
     ?assertEqual({
@@ -338,30 +342,30 @@ pair_with_pair_with_gcounter_and_gmap_and_gmap_test(_Config) ->
     ?assertEqual({?PAIR_TYPE, {
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, []},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
     }}, Pair0),
     ?assertEqual({?PAIR_TYPE, {
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, []},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}
     }}, Pair1),
     ?assertEqual({?PAIR_TYPE, {
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, []}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([])}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}
     }}, Pair2),
     ?assertEqual({?PAIR_TYPE, {
         {?PAIR_TYPE, {
             {?GCOUNTER_TYPE, [{Actor, 1}]},
-            {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
+            {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}
         }},
-        {?GMAP_TYPE, {?BOOLEAN_TYPE, [{Actor, {?BOOLEAN_TYPE, 1}}]}}
+        {?GMAP_TYPE, {?BOOLEAN_TYPE, dict:from_list([{Actor, {?BOOLEAN_TYPE, 1}}])}}
     }}, Pair3),
     ?assertEqual({
         {1, [{Actor, true}]},
@@ -377,10 +381,10 @@ gmap_with_pair_test(_Config) ->
     {ok, GMap3} = ?GMAP_TYPE:mutate({apply, Actor, {snd, true}}, Actor, GMap1),
     Query = ?GMAP_TYPE:query(GMap3),
 
-    ?assertEqual({?GMAP_TYPE, {CType, []}}, GMap0),
-    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 0}}}}]}}, GMap1),
-    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 0}, {?BOOLEAN_TYPE, 1}}}}]}}, GMap2),
-    ?assertEqual({?GMAP_TYPE, {CType, [{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 1}}}}]}}, GMap3),
+    ?assertEqual({?GMAP_TYPE, {CType, dict:from_list([])}}, GMap0),
+    ?assertEqual({?GMAP_TYPE, {CType, dict:from_list([{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 0}}}}])}}, GMap1),
+    ?assertEqual({?GMAP_TYPE, {CType, dict:from_list([{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 0}, {?BOOLEAN_TYPE, 1}}}}])}}, GMap2),
+    ?assertEqual({?GMAP_TYPE, {CType, dict:from_list([{Actor, {?PAIR_TYPE, {{?BOOLEAN_TYPE, 1}, {?BOOLEAN_TYPE, 1}}}}])}}, GMap3),
     ?assertEqual([{Actor, {true, true}}], Query).
 
 maps_within_maps_test(_Config) ->


### PR DESCRIPTION
- GMap join-decomposition
- LWWRegister strict and irreducible strict inflation checks
- CRDT size functions that return a pair where the first component represents the metadata size and the second component the payload size
- GMap: orddict -> dict