### PR TITLE
Fix causal context compression

### DIFF
--- a/src/causal_context.erl
+++ b/src/causal_context.erl
@@ -89,7 +89,16 @@ add_dot({Actor, Sequence}=Dot, {Compressed0, DotSet0}=CC) ->
         true ->
             %% update the compressed component
             Compressed1 = orddict:store(Actor, Sequence, Compressed0),
-            {Compressed1, DotSet0};
+
+            %% and try to compress if the next
+            %% dot of this actor belongs to the
+            %% set of outstanding dots
+            CC1 =  {Compressed1, DotSet0},
+            NextDot = {Actor, Sequence + 1},
+            case dot_set:is_element(NextDot, DotSet0) of
+                true -> compress(CC1);
+                false -> CC1
+            end;
         false ->
             case Sequence > Current + 1 of
                 true ->

--- a/test/prop_causal_context.erl
+++ b/test/prop_causal_context.erl
@@ -126,9 +126,23 @@ prop_union() ->
     ).
 
 %% @private
-ds(L) ->
-    dot_set:from_dots(L).
+cc(L) ->
+    lists:foldl(
+        fun(Dot, CC) ->
+            causal_context:add_dot(Dot, CC)
+        end,
+        causal_context:new(),
+        shuffle(L)
+    ).
 
 %% @private
-cc(L) ->
-    causal_context:from_dot_set(ds(L)).
+shuffle(L) ->
+    rand:seed(exsplus, erlang:timestamp()),
+    lists:map(
+        fun({_, E}) -> E end,
+        lists:sort(
+            lists:map(
+                fun(E) -> {rand:uniform(), E} end, L
+            )
+        )
+    ).


### PR DESCRIPTION
Current implementation of `add_dot\2` assumes causal order when adding dots to the causal context (and it shouldn't).

The bug wasn't caught in the property tests because we were transforming the randomized traces in causally ordered executions.

Both are fixed now.